### PR TITLE
Add CommentSyntax option for non-TypeScript files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `CommentSyntax` option plumbed through `CodeFile`, `CodeBuilder`, the
+  docblock helpers, the manual-section helpers, and the codelock helpers.
+  Construct `new CodeFile(path, { commentSyntax: { kind: "line", prefix: "# " } })`
+  to generate files whose only comment form is a line prefix (e.g.
+  `.gitattributes`). The default remains `{ kind: "jsdoc" }`, preserving the
+  existing JSDoc/C-style output byte-for-byte.
+- `CommentSyntax` is re-exported from the package root.
+
 ### Changed
 
 - **Migrated test runner from Jest to Vitest.** Simpler setup, no `ts-jest` transformer required, and faster runs.

--- a/README.md
+++ b/README.md
@@ -115,3 +115,52 @@ class Steam extends Water {
   }
 }
 ```
+
+## Generating non-TypeScript files
+
+By default, `CodeFile` emits JSDoc/C-style docblocks and manual section
+markers. Pass a `commentSyntax` option to target file formats that only
+support line comments (e.g. `.gitattributes` with `#` comments, shell scripts,
+or a `.ts` file where you prefer `//` docblocks):
+
+```typescript
+export type CommentSyntax =
+  | { kind: "jsdoc" } // default — JSDoc/C-style
+  | { kind: "line"; prefix: string }; // e.g. "# " or "// "
+```
+
+Example `.gitattributes` generator:
+
+```typescript
+new CodeFile(".gitattributes", {
+  commentSyntax: { kind: "line", prefix: "# " },
+})
+  .build((b) =>
+    b
+      .addManualSection("manual", (m) => m.addLine("# add custom rules here"))
+      .addLine("path/to/generated.ts linguist-generated=true"),
+  )
+  .lock("\nTo update this file, run: npm run generate:gitattributes\n")
+  .saveToFile();
+```
+
+Sample output:
+
+```
+# This file is generated with manually editable sections. Only make
+# modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
+# designators.
+#
+# To update this file, run: npm run generate:gitattributes
+#
+# @generated-editable Codelock<<...>>
+
+# BEGIN MANUAL SECTION manual
+# add custom rules here
+# END MANUAL SECTION
+path/to/generated.ts linguist-generated=true
+```
+
+Everything else works the same: `verify()` detects tampering outside the
+manual sections, `lock()` adds the hash, and `saveToFile()` writes the
+result. Manual-section keys still must be non-empty and whitespace-free.

--- a/src/CodeBuilder.ts
+++ b/src/CodeBuilder.ts
@@ -2,15 +2,21 @@ import syncPrettier from "@prettier/sync";
 import { createManualSection } from "./sections/manual";
 import type { ManualSectionMap } from "./types/ManualSectionMap";
 import { createDocblock } from "./sections/docblock";
+import { CommentSyntax, DEFAULT_COMMENT_SYNTAX } from "./types/CommentSyntax";
 
 export class CodeBuilder {
   #gennedCode = "";
   #hasManualSections = false;
 
   readonly #existingManualSections: ManualSectionMap;
+  readonly #commentSyntax: CommentSyntax;
 
-  constructor(manualSections: ManualSectionMap) {
+  constructor(
+    manualSections: ManualSectionMap,
+    commentSyntax: CommentSyntax = DEFAULT_COMMENT_SYNTAX,
+  ) {
     this.#existingManualSections = manualSections;
+    this.#commentSyntax = commentSyntax;
   }
 
   /**
@@ -36,7 +42,7 @@ export class CodeBuilder {
    * @param docblockContent Plain docblock content (i.e. without "*"s at the start of each line)
    */
   addDocblock(docblockContent: string): this {
-    return this.addLine(createDocblock(docblockContent));
+    return this.addLine(createDocblock(docblockContent, this.#commentSyntax));
   }
 
   /**
@@ -51,7 +57,7 @@ export class CodeBuilder {
     blockBuilder: (blockBuilder: CodeBuilder) => CodeBuilder,
   ): this {
     const builtBlockBuilder = blockBuilder(
-      new CodeBuilder(this.#existingManualSections),
+      new CodeBuilder(this.#existingManualSections, this.#commentSyntax),
     );
     this.#hasManualSections =
       this.#hasManualSections || builtBlockBuilder.hasManualSections();
@@ -78,11 +84,13 @@ export class CodeBuilder {
       sectionContent = this.#existingManualSections[sectionKey];
     } else {
       sectionContent = sectionBuilder(
-        new CodeBuilder(this.#existingManualSections),
+        new CodeBuilder(this.#existingManualSections, this.#commentSyntax),
       ).toString();
     }
     this.#hasManualSections = true;
-    return this.addLine(createManualSection(sectionKey, sectionContent));
+    return this.addLine(
+      createManualSection(sectionKey, sectionContent, this.#commentSyntax),
+    );
   }
 
   /**

--- a/src/CodeFile.ts
+++ b/src/CodeFile.ts
@@ -2,23 +2,35 @@ import fs from "fs";
 import { CodeBuilder } from "./CodeBuilder";
 import { verifyLock, lockCode, getCodelockInfo } from "./codelock";
 import { extractManualSections } from "./sections/manual";
+import { CommentSyntax, DEFAULT_COMMENT_SYNTAX } from "./types/CommentSyntax";
+
+export interface CodeFileOptions {
+  /**
+   * Comment syntax used by the file. Defaults to `{ kind: "jsdoc" }`, which
+   * preserves the historical JSDoc/C-style behaviour.
+   */
+  commentSyntax?: CommentSyntax;
+}
 
 /**
  * Represents and manipulates a generated code file.
  */
 export class CodeFile {
   readonly #sourceFilePath: string;
+  readonly #commentSyntax: CommentSyntax;
   #originalFileContents = "";
   #fileContents = "";
   #manualSectionsAllowed: boolean | undefined;
 
-  constructor(sourceFilePath: string) {
+  constructor(sourceFilePath: string, options: CodeFileOptions = {}) {
     this.#sourceFilePath = sourceFilePath;
+    this.#commentSyntax = options.commentSyntax ?? DEFAULT_COMMENT_SYNTAX;
     if (fs.existsSync(sourceFilePath)) {
       this.#originalFileContents = fs.readFileSync(sourceFilePath, "utf-8");
       this.#fileContents = this.#originalFileContents;
       this.#manualSectionsAllowed = getCodelockInfo(
         this.#fileContents,
+        this.#commentSyntax,
       )?.manualSectionsAllowed;
     }
   }
@@ -27,7 +39,7 @@ export class CodeFile {
    * Verifies that the codelock in the generated file is present and valid.
    */
   verify(): boolean {
-    return verifyLock(this.#fileContents);
+    return verifyLock(this.#fileContents, this.#commentSyntax);
   }
 
   /**
@@ -38,7 +50,10 @@ export class CodeFile {
    */
   build(builderBuilder: (builder: CodeBuilder) => CodeBuilder): this {
     const builder = builderBuilder(
-      new CodeBuilder(extractManualSections(this.#fileContents)),
+      new CodeBuilder(
+        extractManualSections(this.#fileContents, this.#commentSyntax),
+        this.#commentSyntax,
+      ),
     );
     this.#fileContents = builder.toString();
     this.#manualSectionsAllowed = builder.hasManualSections();
@@ -59,6 +74,7 @@ export class CodeFile {
       this.#fileContents,
       this.#manualSectionsAllowed ?? false,
       customComment,
+      this.#commentSyntax,
     );
     return this;
   }

--- a/src/__snapshots__/integration.test.ts.snap
+++ b/src/__snapshots__/integration.test.ts.snap
@@ -1,0 +1,147 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`integration: generated file examples > TypeScript file with a custom lock comment (regeneration instructions) 1`] = `
+"/**
+ * This file is generated. Do not modify it manually.
+ *
+ * Regenerate this file by running:
+ * \`npx gentgen generate src/schemas/UserSchema.ts\`
+ *
+ * @generated Codelock<<X9NNKj799cJAuIBLqoyfYgmkVybzMNie>>
+ */
+
+/**
+ * User schema, generated from the canonical model.
+ */
+export interface User {
+  id: string;
+  email: string;
+}
+"
+`;
+
+exports[`integration: generated file examples > editable TypeScript class with manual sections and Prettier formatting 1`] = `
+"/**
+ * This file is generated with manually editable sections. Only make
+ * modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
+ * designators.
+ *
+ * @generated-editable Codelock<<Qe8LJaSFM2Z2LXSgccvK93WyrqNOc3sp>>
+ */
+
+import path from "path";
+import fs from "fs";
+
+/* BEGIN MANUAL SECTION custom_imports */
+/* END MANUAL SECTION */
+
+class Steam extends Water {
+  constructor() {
+    this.boil();
+  }
+
+  boil() {
+    /* BEGIN MANUAL SECTION boil_body */
+    this.temp = 100;
+    /* END MANUAL SECTION */
+  }
+}
+"
+`;
+
+exports[`integration: generated file examples > line syntax: .gitattributes with editable manual section 1`] = `
+"# This file is generated with manually editable sections. Only make
+# modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
+# designators.
+#
+# To update this file, run: npm run generate:gitattributes
+#
+# @generated-editable Codelock<<YLmBD+Buu/NOwEVBoHTsON2B3jCytIIX>>
+
+# BEGIN MANUAL SECTION manual
+# add custom rules here
+# END MANUAL SECTION
+path/to/generated.ts linguist-generated=true
+**/*.snap linguist-generated=true
+"
+`;
+
+exports[`integration: generated file examples > line syntax: TypeScript file with '// ' prefix and an editable manual section 1`] = `
+"// This file is generated with manually editable sections. Only make
+// modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
+// designators.
+//
+// @generated-editable Codelock<<V9HOyNbXUHF6t59SGPusmYt8V12VFNcp>>
+
+export const apiBaseUrl = 'https://api.example.com';
+
+// BEGIN MANUAL SECTION overrides
+// Override config here if needed.
+// END MANUAL SECTION
+"
+`;
+
+exports[`integration: generated file examples > line syntax: regenerating preserves manual section content 1`] = `
+"# This file is generated with manually editable sections. Only make
+# modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
+# designators.
+#
+# @generated-editable Codelock<<ykQLh5QxmvotySsDJPMDYkVcee1Yxnzm>>
+
+# BEGIN MANUAL SECTION manual
+# add custom rules here
+my/secret/lockfile.json linguist-vendored
+# END MANUAL SECTION
+path/to/generated.ts linguist-generated=true
+"
+`;
+
+exports[`integration: generated file examples > line syntax: uneditable shell script with '# ' prefix 1`] = `
+"# This file is generated. Do not modify it manually.
+#
+# @generated Codelock<<FbijbkpZI2CDRh/FrJ7DTp0D7p5ddHJD>>
+
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo 'Deploying version 1.2.3'
+./scripts/deploy.sh --version 1.2.3
+"
+`;
+
+exports[`integration: generated file examples > regenerating an editable file preserves existing manual section content 1`] = `
+"/**
+ * This file is generated with manually editable sections. Only make
+ * modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
+ * designators.
+ *
+ * @generated-editable Codelock<<qtt9w2cPNbqw17quFBDPaw3IcVR/xvVt>>
+ */
+
+export class Greeter {
+  greet(name: string) {
+    /* BEGIN MANUAL SECTION greet_body */
+    if (name.length === 0) {
+      return "Hello, stranger!";
+    }
+    return \`Hello, \${name.toUpperCase()}!\`;
+    /* END MANUAL SECTION */
+  }
+}
+"
+`;
+
+exports[`integration: generated file examples > uneditable TypeScript constants file 1`] = `
+"/**
+ * This file is generated. Do not modify it manually.
+ *
+ * @generated Codelock<<Lh0qMi/ND1WXJFr3lHm5t0at8+qqMqBr>>
+ */
+
+export const Colors = {
+  RED: "#ff0000",
+  GREEN: "#00ff00",
+  BLUE: "#0000ff",
+} as const;
+"
+`;

--- a/src/codelock.test.ts
+++ b/src/codelock.test.ts
@@ -206,3 +206,130 @@ describe("reversibility", () => {
     );
   });
 });
+
+describe("line comment syntax", () => {
+  const syntax = { kind: "line", prefix: "# " } as const;
+
+  const gitattributesBody = `
+# BEGIN MANUAL SECTION manual
+# add custom rules here
+# END MANUAL SECTION
+
+path/to/generated.ts linguist-generated=true
+`.trim();
+
+  const gitattributesWithoutManualSections = `
+path/to/generated.ts linguist-generated=true
+`.trim();
+
+  describe(lockCode, () => {
+    test("should prepend a line-comment docblock with an editable lock", () => {
+      const locked = lockCode(gitattributesBody, true, "", syntax);
+      expect(locked).toContain("# @generated-editable Codelock<<");
+      expect(locked.startsWith("# This file is generated")).toBe(true);
+      expect(locked).toContain(gitattributesBody);
+    });
+
+    test("should prepend a line-comment docblock with an uneditable lock", () => {
+      const locked = lockCode(
+        gitattributesWithoutManualSections,
+        false,
+        "",
+        syntax,
+      );
+      expect(locked).toContain("# @generated Codelock<<");
+      expect(locked).not.toContain("# @generated-editable");
+    });
+
+    test("should interpolate provided customContent as line comments", () => {
+      const locked = lockCode(
+        gitattributesBody,
+        true,
+        "\nTo update: run codegen\n",
+        syntax,
+      );
+      expect(locked).toContain("# To update: run codegen");
+    });
+  });
+
+  describe(getCodelockInfo, () => {
+    test("returns manualSectionsAllowed: true for editable lock", () => {
+      const locked = lockCode(gitattributesBody, true, "", syntax);
+      expect(getCodelockInfo(locked, syntax)).toMatchObject({
+        manualSectionsAllowed: true,
+      });
+    });
+
+    test("returns manualSectionsAllowed: false for uneditable lock", () => {
+      const locked = lockCode(
+        gitattributesWithoutManualSections,
+        false,
+        "",
+        syntax,
+      );
+      expect(getCodelockInfo(locked, syntax)).toMatchObject({
+        manualSectionsAllowed: false,
+      });
+    });
+
+    test("returns undefined if code has no docblock", () => {
+      expect(getCodelockInfo("", syntax)).toBeUndefined();
+      expect(getCodelockInfo(gitattributesBody, syntax)).toBeUndefined();
+    });
+  });
+
+  describe(verifyLock, () => {
+    test("returns true after locking", () => {
+      expect(
+        verifyLock(lockCode(gitattributesBody, true, "", syntax), syntax),
+      ).toBe(true);
+      expect(
+        verifyLock(
+          lockCode(gitattributesWithoutManualSections, false, "", syntax),
+          syntax,
+        ),
+      ).toBe(true);
+    });
+
+    test("returns false if the body is edited outside of manual sections", () => {
+      expect(
+        verifyLock(
+          lockCode(gitattributesBody, true, "", syntax) +
+            "\nextra/file linguist-generated=true\n",
+          syntax,
+        ),
+      ).toBe(false);
+      expect(
+        verifyLock(
+          lockCode(gitattributesWithoutManualSections, false, "", syntax) +
+            "\nextra/file linguist-generated=true\n",
+          syntax,
+        ),
+      ).toBe(false);
+    });
+
+    test("returns true if only the manual section body is edited in an editable lock", () => {
+      const locked = lockCode(gitattributesBody, true, "", syntax);
+      const edited = locked.replace(
+        "# BEGIN MANUAL SECTION manual\n# add custom rules here\n# END MANUAL SECTION",
+        "# BEGIN MANUAL SECTION manual\n# add custom rules here\npath/to/extra lfs\n# END MANUAL SECTION",
+      );
+      expect(verifyLock(edited, syntax)).toBe(true);
+    });
+
+    test("returns false if the manual section body is edited in an uneditable lock", () => {
+      const body = `
+# BEGIN MANUAL SECTION manual
+# END MANUAL SECTION
+
+path/to/generated.ts linguist-generated=true
+`.trim();
+      const locked = lockCode(body, false, "", syntax);
+      const edited = locked.replace(
+        "# BEGIN MANUAL SECTION manual\n# END MANUAL SECTION",
+        "# BEGIN MANUAL SECTION manual\npath/to/extra lfs\n# END MANUAL SECTION",
+      );
+      expect(verifyLock(edited, syntax)).toBe(false);
+    });
+  });
+});

--- a/src/codelock.ts
+++ b/src/codelock.ts
@@ -5,6 +5,7 @@ import {
   prependFileDocblock,
 } from "./sections/docblock";
 import { emptyManualSections } from "./sections/manual";
+import { CommentSyntax, DEFAULT_COMMENT_SYNTAX } from "./types/CommentSyntax";
 
 interface CodelockInfo {
   hash: string;
@@ -15,10 +16,13 @@ interface CodelockInfo {
  * Get codelock information from a locked source file.
  *
  * @param lockedCode Code in source file, prepended with codelock file docblock.
+ * @param syntax Comment syntax used in the file. Defaults to JSDoc.
  */
-export function getCodelockInfo(lockedCode: string): CodelockInfo | undefined {
-  // TODO: get docblock, and if it exists, retrieve hash
-  const docblock = getFileDocblock(lockedCode);
+export function getCodelockInfo(
+  lockedCode: string,
+  syntax: CommentSyntax = DEFAULT_COMMENT_SYNTAX,
+): CodelockInfo | undefined {
+  const docblock = getFileDocblock(lockedCode, syntax);
   if (!docblock) {
     return undefined;
   }
@@ -28,7 +32,6 @@ export function getCodelockInfo(lockedCode: string): CodelockInfo | undefined {
     return undefined;
   }
 
-  // Expect codelock info to be on the last line.
   const lockline = docblockLines[docblockLines.length - 1];
 
   const editableMatchGroups =
@@ -59,11 +62,16 @@ export function getCodelockInfo(lockedCode: string): CodelockInfo | undefined {
  * @param code Code to be locked.
  * @param shouldEmptyManualSections Whether manual sections should be emptied.
  * Should = whether the file is allowed to have manual sections.
+ * @param syntax Comment syntax used in the file. Defaults to JSDoc.
  * @returns Lock hash for `code`.
  */
-function computeHash(code: string, shouldEmptyManualSections: boolean): string {
+function computeHash(
+  code: string,
+  shouldEmptyManualSections: boolean,
+  syntax: CommentSyntax,
+): string {
   const hashableCode = (
-    shouldEmptyManualSections ? emptyManualSections(code) : code
+    shouldEmptyManualSections ? emptyManualSections(code, syntax) : code
   ).trim();
   return crypto
     .createHash("shake128", { outputLength: 24 })
@@ -79,14 +87,16 @@ function computeHash(code: string, shouldEmptyManualSections: boolean): string {
  * @param code Code to be locked.
  * @param manualSectionsAllowed Whether generated code can contain manual sections.
  * @param customContent A custom comment to insert into the docblock.
+ * @param syntax Comment syntax used in the file. Defaults to JSDoc.
  * @returns Locked code, i.e. code with prepended codelock file docblock.
  */
 export function lockCode(
   code: string,
   manualSectionsAllowed: boolean,
   customContent = "",
+  syntax: CommentSyntax = DEFAULT_COMMENT_SYNTAX,
 ): string {
-  const hash = computeHash(code, manualSectionsAllowed);
+  const hash = computeHash(code, manualSectionsAllowed, syntax);
 
   let docblockContent;
 
@@ -102,25 +112,30 @@ ${customContent}
 @generated Codelock<<${hash}>>`;
   }
 
-  return prependFileDocblock(code, docblockContent);
+  return prependFileDocblock(code, docblockContent, syntax);
 }
 
 /**
  * Verify that the codelock in the source file is valid.
  *
  * @param lockedCode Locked code to be verified.
+ * @param syntax Comment syntax used in the file. Defaults to JSDoc.
  * @returns `true` if lock is found and verified. `false` otherwise.
  */
-export function verifyLock(lockedCode: string): boolean {
-  const codeblockInfo = getCodelockInfo(lockedCode);
+export function verifyLock(
+  lockedCode: string,
+  syntax: CommentSyntax = DEFAULT_COMMENT_SYNTAX,
+): boolean {
+  const codeblockInfo = getCodelockInfo(lockedCode, syntax);
   if (!codeblockInfo) {
     return false;
   }
   return (
     codeblockInfo.hash ===
     computeHash(
-      removeFileDocblock(lockedCode),
+      removeFileDocblock(lockedCode, syntax),
       codeblockInfo.manualSectionsAllowed,
+      syntax,
     )
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./CodeFile";
 export * from "./CodeBuilder";
 export * from "./types/ManualSectionMap";
+export * from "./types/CommentSyntax";

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,0 +1,256 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { CodeFile } from "./CodeFile";
+
+/**
+ * End-to-end integration tests that exercise the public API (`CodeFile`,
+ * `CodeBuilder`) and snapshot the final on-disk output of representative
+ * generated files. Read the committed snapshot file alongside this test to
+ * see what generated files produced by tscodegen look like in practice.
+ */
+
+function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "tscodegen-integration-"));
+}
+
+function removeDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe("integration: generated file examples", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+  });
+
+  afterEach(() => {
+    removeDir(tmpDir);
+  });
+
+  /**
+   * Build a file, lock it, save it to disk, and return the bytes that ended
+   * up on disk. Using `fs.readFileSync` here (rather than
+   * `CodeFile.toString`) makes the snapshots a faithful representation of
+   * what consumers of tscodegen actually get on disk.
+   */
+  function buildAndSave(
+    fileName: string,
+    configure: (file: CodeFile) => CodeFile,
+  ): string {
+    const filePath = path.join(tmpDir, fileName);
+    configure(new CodeFile(filePath)).saveToFile();
+    return fs.readFileSync(filePath, "utf-8");
+  }
+
+  test("editable TypeScript class with manual sections and Prettier formatting", () => {
+    const output = buildAndSave("Steam.ts", (file) =>
+      file
+        .build((b) =>
+          b
+            .addLine("import path from 'path';")
+            .addLine("import fs from 'fs'")
+            .addLine()
+            .addManualSection("custom_imports", (builder) => builder)
+            .addLine()
+            .addBlock("class Steam extends Water", (builder) =>
+              builder
+                .addBlock("constructor()", (c) => c.addLine("this.boil();"))
+                .addLine()
+                .addBlock("boil()", (bb) =>
+                  bb.addManualSection("boil_body", (m) =>
+                    m.add("this.temp = 100;"),
+                  ),
+                ),
+            )
+            .format(),
+        )
+        .lock(),
+    );
+    expect(output).toMatchSnapshot();
+  });
+
+  test("uneditable TypeScript constants file", () => {
+    const output = buildAndSave("Colors.ts", (file) =>
+      file
+        .build((b) =>
+          b
+            .addLine("export const Colors = {")
+            .addLine("  RED: '#ff0000',")
+            .addLine("  GREEN: '#00ff00',")
+            .addLine("  BLUE: '#0000ff',")
+            .addLine("} as const;")
+            .format(),
+        )
+        .lock(),
+    );
+    expect(output).toMatchSnapshot();
+  });
+
+  test("TypeScript file with a custom lock comment (regeneration instructions)", () => {
+    const output = buildAndSave("UserSchema.ts", (file) =>
+      file
+        .build((b) =>
+          b
+            .addDocblock("User schema, generated from the canonical model.")
+            .addLine("export interface User {")
+            .addLine("  id: string;")
+            .addLine("  email: string;")
+            .addLine("}")
+            .format(),
+        )
+        .lock(
+          "\nRegenerate this file by running:\n`npx gentgen generate src/schemas/UserSchema.ts`\n",
+        ),
+    );
+    expect(output).toMatchSnapshot();
+  });
+
+  test("regenerating an editable file preserves existing manual section content", () => {
+    const filePath = path.join(tmpDir, "Greeter.ts");
+
+    // First generation: produce and save the initial file.
+    new CodeFile(filePath)
+      .build((b) =>
+        b
+          .addBlock("export class Greeter", (cls) =>
+            cls.addBlock("greet(name: string)", (fn) =>
+              fn.addManualSection("greet_body", (m) =>
+                m.addLine("return `Hello, ${name}!`;"),
+              ),
+            ),
+          )
+          .format(),
+      )
+      .lock()
+      .saveToFile();
+
+    // Simulate a user editing the manual section on disk.
+    const initialContents = fs.readFileSync(filePath, "utf-8");
+    const editedContents = initialContents.replace(
+      "return `Hello, ${name}!`;",
+      [
+        "if (name.length === 0) {",
+        '  return "Hello, stranger!";',
+        "}",
+        "return `Hello, ${name.toUpperCase()}!`;",
+      ].join("\n"),
+    );
+    fs.writeFileSync(filePath, editedContents, "utf-8");
+
+    // Second generation: identical builder, but the manual section content
+    // should be preserved from disk rather than re-emitted.
+    const regenerated = buildAndSave("Greeter.ts", (file) =>
+      file
+        .build((b) =>
+          b
+            .addBlock("export class Greeter", (cls) =>
+              cls.addBlock("greet(name: string)", (fn) =>
+                fn.addManualSection("greet_body", (m) =>
+                  m.addLine("return `Hello, ${name}!`;"),
+                ),
+              ),
+            )
+            .format(),
+        )
+        .lock(),
+    );
+    expect(regenerated).toMatchSnapshot();
+  });
+
+  test("line syntax: .gitattributes with editable manual section", () => {
+    const filePath = path.join(tmpDir, ".gitattributes");
+    new CodeFile(filePath, {
+      commentSyntax: { kind: "line", prefix: "# " },
+    })
+      .build((b) =>
+        b
+          .addManualSection("manual", (m) =>
+            m.addLine("# add custom rules here"),
+          )
+          .addLine("path/to/generated.ts linguist-generated=true")
+          .addLine("**/*.snap linguist-generated=true"),
+      )
+      .lock("\nTo update this file, run: npm run generate:gitattributes\n")
+      .saveToFile();
+    expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
+  });
+
+  test("line syntax: uneditable shell script with '# ' prefix", () => {
+    const filePath = path.join(tmpDir, "deploy.sh");
+    new CodeFile(filePath, {
+      commentSyntax: { kind: "line", prefix: "# " },
+    })
+      .build((b) =>
+        b
+          .addLine("#!/usr/bin/env bash")
+          .addLine("set -euo pipefail")
+          .addLine()
+          .addLine("echo 'Deploying version 1.2.3'")
+          .addLine("./scripts/deploy.sh --version 1.2.3"),
+      )
+      .lock()
+      .saveToFile();
+    expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
+  });
+
+  test("line syntax: TypeScript file with '// ' prefix and an editable manual section", () => {
+    const filePath = path.join(tmpDir, "generated-config.ts");
+    new CodeFile(filePath, {
+      commentSyntax: { kind: "line", prefix: "// " },
+    })
+      .build((b) =>
+        b
+          .addLine("export const apiBaseUrl = 'https://api.example.com';")
+          .addLine()
+          .addManualSection("overrides", (m) =>
+            m.addLine("// Override config here if needed."),
+          ),
+      )
+      .lock()
+      .saveToFile();
+    expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
+  });
+
+  test("line syntax: regenerating preserves manual section content", () => {
+    const filePath = path.join(tmpDir, ".gitattributes");
+    const syntax = { kind: "line" as const, prefix: "# " };
+
+    new CodeFile(filePath, { commentSyntax: syntax })
+      .build((b) =>
+        b
+          .addManualSection("manual", (m) =>
+            m.addLine("# add custom rules here"),
+          )
+          .addLine("path/to/generated.ts linguist-generated=true"),
+      )
+      .lock()
+      .saveToFile();
+
+    // Simulate a human adding a custom rule inside the manual section.
+    const initial = fs.readFileSync(filePath, "utf-8");
+    fs.writeFileSync(
+      filePath,
+      initial.replace(
+        "# add custom rules here",
+        "# add custom rules here\nmy/secret/lockfile.json linguist-vendored",
+      ),
+      "utf-8",
+    );
+
+    new CodeFile(filePath, { commentSyntax: syntax })
+      .build((b) =>
+        b
+          .addManualSection("manual", (m) =>
+            m.addLine("# add custom rules here"),
+          )
+          .addLine("path/to/generated.ts linguist-generated=true"),
+      )
+      .lock()
+      .saveToFile();
+
+    expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
+  });
+});

--- a/src/sections/docblock.test.ts
+++ b/src/sections/docblock.test.ts
@@ -242,3 +242,127 @@ function add(a, b) {
     );
   });
 });
+
+describe("line comment syntax", () => {
+  const syntax = { kind: "line", prefix: "# " } as const;
+
+  describe(getFileDocblock, () => {
+    test("should return undefined if code does not start with a prefixed line", () => {
+      expect(getFileDocblock("", syntax)).toBeUndefined();
+      expect(
+        getFileDocblock("path linguist-generated=true\n", syntax),
+      ).toBeUndefined();
+    });
+
+    test("should return docblock lines without prefix", () => {
+      expect(
+        getFileDocblock(
+          `# File docblock
+#
+# More info
+#
+# @generated Codelock<<somehash>>
+
+path/to/file linguist-generated=true
+`,
+          syntax,
+        ),
+      ).toBe(
+        `
+File docblock
+
+More info
+
+@generated Codelock<<somehash>>
+        `.trim(),
+      );
+    });
+  });
+
+  describe(removeFileDocblock, () => {
+    test("should passthrough files that do not start with the prefix", () => {
+      expect(removeFileDocblock("", syntax)).toBe("");
+      const code = "path linguist-generated=true\n";
+      expect(removeFileDocblock(code, syntax)).toBe(code);
+    });
+
+    test("should strip the docblock lines", () => {
+      expect(
+        removeFileDocblock(
+          `# File docblock
+#
+# @generated Codelock<<x>>
+
+path/to/file linguist-generated=true
+`,
+          syntax,
+        ),
+      ).toBe(`
+path/to/file linguist-generated=true
+`);
+    });
+  });
+
+  describe(createDocblock, () => {
+    test("should emit one prefixed line per content line with blank lines as bare prefix", () => {
+      expect(
+        createDocblock(
+          `File docblock
+
+More info
+
+@generated Codelock<<abc>>`,
+          syntax,
+        ),
+      ).toBe(`# File docblock
+#
+# More info
+#
+# @generated Codelock<<abc>>`);
+    });
+  });
+
+  describe(prependFileDocblock, () => {
+    test("should prepend docblock lines before existing code", () => {
+      const result = prependFileDocblock(
+        "path/to/file linguist-generated=true\n",
+        "@generated Codelock<<abc>>",
+        syntax,
+      );
+      expect(result).toBe(`# @generated Codelock<<abc>>
+
+path/to/file linguist-generated=true
+`);
+    });
+  });
+
+  describe("reversibility", () => {
+    const docblockContent = `File docblock
+
+More info
+
+@partially-generated: Codelock<<abc123>>`;
+
+    const code = `
+path/to/generated.ts linguist-generated=true
+`;
+
+    test("prepend -> get should return the same content", () => {
+      expect(
+        getFileDocblock(
+          prependFileDocblock(code, docblockContent, syntax),
+          syntax,
+        ),
+      ).toBe(docblockContent);
+    });
+
+    test("prepend -> remove should return the original code", () => {
+      expect(
+        removeFileDocblock(
+          prependFileDocblock(code, docblockContent, syntax),
+          syntax,
+        ),
+      ).toBe(code);
+    });
+  });
+});

--- a/src/sections/docblock.ts
+++ b/src/sections/docblock.ts
@@ -1,4 +1,34 @@
+import { CommentSyntax, DEFAULT_COMMENT_SYNTAX } from "../types/CommentSyntax";
+
 const docblockMatchRegExp = /^\/\*\*\n(?<contents>( \*.*\n)*?) \*\/\n/;
+
+function emptyLinePrefix(prefix: string): string {
+  return prefix.replace(/\s+$/, "");
+}
+
+function isLineInLineDocblock(line: string, prefix: string): boolean {
+  return line.startsWith(prefix) || line === emptyLinePrefix(prefix);
+}
+
+function stripLinePrefix(line: string, prefix: string): string {
+  if (line.startsWith(prefix)) {
+    return line.substring(prefix.length);
+  }
+  return "";
+}
+
+function countLeadingDocblockLines(code: string, prefix: string): number {
+  const lines = code.split("\n");
+  let count = 0;
+  for (const line of lines) {
+    if (isLineInLineDocblock(line, prefix)) {
+      count += 1;
+    } else {
+      break;
+    }
+  }
+  return count;
+}
 
 /**
  * Get file docblock from `code`, the contents of a source file.
@@ -7,24 +37,37 @@ const docblockMatchRegExp = /^\/\*\*\n(?<contents>( \*.*\n)*?) \*\/\n/;
  * the file docblock.
  *
  * @param code Code from a source file.
+ * @param syntax Comment syntax used in the file. Defaults to JSDoc.
  * @returns Docblock if it exists, else returns undefined.
  */
-export function getFileDocblock(code: string): string | undefined {
-  const rawDocblockMatchGroups = docblockMatchRegExp.exec(code)?.groups;
-  if (!rawDocblockMatchGroups) {
-    return undefined;
-  }
+export function getFileDocblock(
+  code: string,
+  syntax: CommentSyntax = DEFAULT_COMMENT_SYNTAX,
+): string | undefined {
+  if (syntax.kind === "jsdoc") {
+    const rawDocblockMatchGroups = docblockMatchRegExp.exec(code)?.groups;
+    if (!rawDocblockMatchGroups) {
+      return undefined;
+    }
 
-  const rawContents = rawDocblockMatchGroups.contents;
-  return (
-    rawContents
-      // Remove each line's leading " *"
+    const rawContents = rawDocblockMatchGroups.contents;
+    return rawContents
       .split("\n")
       .map((line) => line.substring(" *".length).trim())
       .join("\n")
-      // Remove trailing \n
-      .trim()
-  );
+      .trim();
+  }
+
+  const { prefix } = syntax;
+  const leadingCount = countLeadingDocblockLines(code, prefix);
+  if (leadingCount === 0) {
+    return undefined;
+  }
+  const lines = code.split("\n").slice(0, leadingCount);
+  return lines
+    .map((line) => stripLinePrefix(line, prefix))
+    .join("\n")
+    .trim();
 }
 
 /**
@@ -34,26 +77,55 @@ export function getFileDocblock(code: string): string | undefined {
  * the file docblock.
  *
  * @param code Code from a source file.
+ * @param syntax Comment syntax used in the file. Defaults to JSDoc.
  */
-export function removeFileDocblock(code: string): string {
-  if (!docblockMatchRegExp.exec(code)) {
+export function removeFileDocblock(
+  code: string,
+  syntax: CommentSyntax = DEFAULT_COMMENT_SYNTAX,
+): string {
+  if (syntax.kind === "jsdoc") {
+    if (!docblockMatchRegExp.exec(code)) {
+      return code;
+    }
+    return code.replace(docblockMatchRegExp, "");
+  }
+
+  const { prefix } = syntax;
+  const leadingCount = countLeadingDocblockLines(code, prefix);
+  if (leadingCount === 0) {
     return code;
   }
-  return code.replace(docblockMatchRegExp, "");
+  // Consume the leading docblock lines together with their trailing newlines.
+  // The JSDoc variant similarly consumes the final `*/\n` but leaves any
+  // additional blank separator intact.
+  const lines = code.split("\n");
+  return lines.slice(leadingCount).join("\n");
 }
 
 /**
  * Creates a docblock from `docblockContent`.
  *
  * @param docblockContent Plain docblock content (i.e. without "*"s at the start of each line)
+ * @param syntax Comment syntax to use when emitting the docblock.
  */
-export function createDocblock(docblockContent: string): string {
-  const docblockContentWithLeadingStars = docblockContent
+export function createDocblock(
+  docblockContent: string,
+  syntax: CommentSyntax = DEFAULT_COMMENT_SYNTAX,
+): string {
+  if (syntax.kind === "jsdoc") {
+    const docblockContentWithLeadingStars = docblockContent
+      .split("\n")
+      .map((line) => ` ${`* ${line}`.trim()}`)
+      .join("\n");
+    return `/**\n${docblockContentWithLeadingStars}\n */`;
+  }
+
+  const { prefix } = syntax;
+  const emptyPrefix = emptyLinePrefix(prefix);
+  return docblockContent
     .split("\n")
-    .map((line) => ` ${`* ${line}`.trim()}`) // " *" for empty lines, ` * ${line}` otherwise
+    .map((line) => (line.length === 0 ? emptyPrefix : `${prefix}${line}`))
     .join("\n");
-  const docblock = `/**\n${docblockContentWithLeadingStars}\n */`;
-  return docblock;
 }
 
 /**
@@ -62,10 +134,12 @@ export function createDocblock(docblockContent: string): string {
  *
  * @param code Code from a source file.
  * @param docblockContent Plain docblock content (i.e. without "*"s at the start of each line)
+ * @param syntax Comment syntax to use when emitting the docblock.
  */
 export function prependFileDocblock(
   code: string,
   docblockContent: string,
+  syntax: CommentSyntax = DEFAULT_COMMENT_SYNTAX,
 ): string {
-  return `${createDocblock(docblockContent)}\n\n${code.trimStart()}`;
+  return `${createDocblock(docblockContent, syntax)}\n\n${code.trimStart()}`;
 }

--- a/src/sections/manual.test.ts
+++ b/src/sections/manual.test.ts
@@ -259,4 +259,100 @@ describe(emptyManualSections, () => {
   });
 });
 
+describe("line comment syntax", () => {
+  const syntax = { kind: "line", prefix: "# " } as const;
+
+  describe(createManualSection, () => {
+    test("should throw if section key is empty or has whitespaces", () => {
+      expect(() => createManualSection("", "CODE", syntax)).toThrow();
+      expect(() => createManualSection("a b", "CODE", syntax)).toThrow();
+    });
+
+    test("should emit line-prefixed begin/end markers", () => {
+      expect(
+        createManualSection("key", "path/to/file -linguist-generated", syntax),
+      ).toBe(`# BEGIN MANUAL SECTION key
+path/to/file -linguist-generated
+# END MANUAL SECTION`);
+    });
+
+    test("should emit empty section without interior content", () => {
+      expect(createManualSection("key", "", syntax)).toBe(
+        `# BEGIN MANUAL SECTION key\n# END MANUAL SECTION`,
+      );
+    });
+  });
+
+  describe(extractManualSections, () => {
+    test("should extract a line-style manual section", () => {
+      expect(
+        extractManualSections(
+          `# BEGIN MANUAL SECTION key
+path/to/custom lfs
+# END MANUAL SECTION
+`,
+          syntax,
+        ),
+      ).toEqual({
+        key: "path/to/custom lfs",
+      });
+    });
+
+    test("should extract multiple line-style manual sections", () => {
+      expect(
+        extractManualSections(
+          `# BEGIN MANUAL SECTION empty
+# END MANUAL SECTION
+
+path/to/generated linguist-generated=true
+
+# BEGIN MANUAL SECTION custom
+path/to/custom lfs
+path/to/another.bin binary
+# END MANUAL SECTION
+`,
+          syntax,
+        ),
+      ).toEqual({
+        empty: "",
+        custom: `path/to/custom lfs
+path/to/another.bin binary`,
+      });
+    });
+  });
+
+  describe(emptyManualSections, () => {
+    test("should empty line-style manual sections", () => {
+      expect(
+        emptyManualSections(
+          `# BEGIN MANUAL SECTION key
+path/to/custom lfs
+# END MANUAL SECTION
+`,
+          syntax,
+        ),
+      ).toBe(`# BEGIN MANUAL SECTION key
+# END MANUAL SECTION
+`);
+    });
+
+    test("should not touch JSDoc-style markers when using line syntax", () => {
+      const code =
+        "/* BEGIN MANUAL SECTION k */\nfoo\n/* END MANUAL SECTION */";
+      expect(emptyManualSections(code, syntax)).toBe(code);
+    });
+  });
+
+  describe("round-trip", () => {
+    test("extract -> re-create yields equivalent body content", () => {
+      const original = `# BEGIN MANUAL SECTION key
+path/to/custom lfs
+# END MANUAL SECTION`;
+      const extracted = extractManualSections(original, syntax);
+      expect(extracted).toEqual({ key: "path/to/custom lfs" });
+      expect(createManualSection("key", extracted.key, syntax)).toBe(original);
+    });
+  });
+});
+
 // TODO: Ensure nuke and create reverse each other

--- a/src/sections/manual.ts
+++ b/src/sections/manual.ts
@@ -1,28 +1,66 @@
 import type { ManualSectionMap } from "../types/ManualSectionMap";
+import { CommentSyntax, DEFAULT_COMMENT_SYNTAX } from "../types/CommentSyntax";
 
-const sectionMatchRegExp =
+const jsdocSectionMatchRegExp =
   /\/\* BEGIN MANUAL SECTION (?<key>\S+) \*\/(?<code>(.|\n)+?|)\/\* END MANUAL SECTION \*\//gm;
 
-export function createManualSection(
-  sectionKey: string,
-  sectionCode: string,
-): string {
-  // Ensure section key is non-empty and contains no whitespaces
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function buildLineSectionMatchRegExp(prefix: string): RegExp {
+  const escapedPrefix = escapeRegExp(prefix);
+  // Anchor both markers to a line start (via the `m` flag) so that the lazy
+  // `code` capture does not greedily swallow an intervening END marker.
+  return new RegExp(
+    `^${escapedPrefix}BEGIN MANUAL SECTION (?<key>\\S+)$\\n(?<code>[\\s\\S]*?)^${escapedPrefix}END MANUAL SECTION$`,
+    "gm",
+  );
+}
+
+function getSectionMatchRegExp(syntax: CommentSyntax): RegExp {
+  if (syntax.kind === "jsdoc") {
+    return new RegExp(
+      jsdocSectionMatchRegExp.source,
+      jsdocSectionMatchRegExp.flags,
+    );
+  }
+  return buildLineSectionMatchRegExp(syntax.prefix);
+}
+
+function validateSectionKey(sectionKey: string): void {
   if (sectionKey.length === 0 || /\s/.test(sectionKey)) {
     throw new Error(
       `Manual section keys should not be empty or contain whitespaces. Received "${sectionKey}".`,
     );
   }
+}
+
+export function createManualSection(
+  sectionKey: string,
+  sectionCode: string,
+  syntax: CommentSyntax = DEFAULT_COMMENT_SYNTAX,
+): string {
+  validateSectionKey(sectionKey);
 
   let processedSectionCode = sectionCode.trim();
   processedSectionCode =
     processedSectionCode.length > 0 ? `${processedSectionCode}\n` : "";
 
-  return `/* BEGIN MANUAL SECTION ${sectionKey} */\n${processedSectionCode}/* END MANUAL SECTION */`;
+  if (syntax.kind === "jsdoc") {
+    return `/* BEGIN MANUAL SECTION ${sectionKey} */\n${processedSectionCode}/* END MANUAL SECTION */`;
+  }
+
+  const { prefix } = syntax;
+  return `${prefix}BEGIN MANUAL SECTION ${sectionKey}\n${processedSectionCode}${prefix}END MANUAL SECTION`;
 }
 
-export function extractManualSections(code: string): ManualSectionMap {
-  const allMatches = code.matchAll(sectionMatchRegExp);
+export function extractManualSections(
+  code: string,
+  syntax: CommentSyntax = DEFAULT_COMMENT_SYNTAX,
+): ManualSectionMap {
+  const regExp = getSectionMatchRegExp(syntax);
+  const allMatches = code.matchAll(regExp);
   const manualSections: ManualSectionMap = {};
   [...allMatches].forEach((match: RegExpMatchArray) => {
     if (!match.groups) {
@@ -37,9 +75,14 @@ export function extractManualSections(code: string): ManualSectionMap {
  * Removes all code between manual section designators.
  *
  * @param code Source code, potentially containing manual sections.
+ * @param syntax Comment syntax used in the file. Defaults to JSDoc.
  */
-export function emptyManualSections(code: string): string {
-  return code.replace(sectionMatchRegExp, (matchedString, sectionKey) =>
-    createManualSection(sectionKey, ""),
+export function emptyManualSections(
+  code: string,
+  syntax: CommentSyntax = DEFAULT_COMMENT_SYNTAX,
+): string {
+  const regExp = getSectionMatchRegExp(syntax);
+  return code.replace(regExp, (_matchedString, sectionKey) =>
+    createManualSection(sectionKey, "", syntax),
   );
 }

--- a/src/types/CommentSyntax.ts
+++ b/src/types/CommentSyntax.ts
@@ -1,0 +1,16 @@
+/**
+ * Describes the comment flavour that should be used when parsing and emitting
+ * file docblocks, manual sections, and codelocks.
+ *
+ * - `{ kind: "jsdoc" }` is the default and preserves the historical
+ *   JSDoc/C-style behaviour (`/** ... *\/` docblocks and
+ *   `/* BEGIN MANUAL SECTION ... *\/` markers).
+ * - `{ kind: "line"; prefix }` is intended for file formats that only support
+ *   line comments. `prefix` is prepended to every emitted line (e.g. `"# "`
+ *   for `.gitattributes`, `"// "` for a non-locked TypeScript file).
+ */
+export type CommentSyntax =
+  | { kind: "jsdoc" }
+  | { kind: "line"; prefix: string };
+
+export const DEFAULT_COMMENT_SYNTAX: CommentSyntax = { kind: "jsdoc" };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extend `@elg/tscodegen` so it can generate files whose only comment form is a line-comment prefix (e.g. `.gitattributes` with `#`, or any file format where `/** ... */` is illegal), while keeping existing JSDoc consumers byte-for-byte identical.

A new `CommentSyntax` option is threaded through every comment-emitting helper:

```typescript
export type CommentSyntax =
  | { kind: "jsdoc" } // default — current behaviour
  | { kind: "line"; prefix: string }; // e.g. "# " or "// "

new CodeFile(path, { commentSyntax?: CommentSyntax });
```

## Changes

- **`src/types/CommentSyntax.ts`**: new type + `DEFAULT_COMMENT_SYNTAX` constant, re-exported from `src/index.ts`.
- **`src/sections/docblock.ts`**: `getFileDocblock`, `removeFileDocblock`, `createDocblock`, and `prependFileDocblock` now take an optional `CommentSyntax`.
  - `jsdoc`: unchanged `/** ... */` behaviour.
  - `line`: a docblock is a contiguous run of lines starting at offset 0 that each begin with the configured prefix; empty content lines are emitted as the prefix with trailing whitespace stripped so we never leave trailing whitespace; trailing blank separator between docblock and body is preserved.
- **`src/sections/manual.ts`**: `createManualSection`, `extractManualSections`, and `emptyManualSections` now take an optional `CommentSyntax`. For `line` syntax they emit/parse:
  ```
  <prefix>BEGIN MANUAL SECTION <key>
  ...body...
  <prefix>END MANUAL SECTION
  ```
  Markers are anchored to line starts with the `m` flag so the lazy body match does not swallow intervening END markers. The "non-empty, whitespace-free" key rule is unchanged.
- **`src/codelock.ts`**: `getCodelockInfo`, `lockCode`, `verifyLock` accept `CommentSyntax`. The lock trailer is still literally `@generated Codelock<<hash>>` / `@generated-editable Codelock<<hash>>` on the last docblock line; for line syntax, the rest of the human-readable comment is emitted as `<prefix>`-prefixed lines above it. `computeHash` forwards the syntax into `emptyManualSections` so the right markers are stripped before hashing.
- **`src/CodeFile.ts`**: new constructor options object `{ commentSyntax?: CommentSyntax }`, defaulting to `{ kind: "jsdoc" }`. Plumbs the syntax into `extractManualSections`, the `CodeBuilder`, and all codelock calls. Public signatures of `verify`, `build`, `lock`, `saveToFile` are unchanged.
- **`src/CodeBuilder.ts`**: new constructor arg `commentSyntax`; propagated to nested builders from `addBlock` / `addManualSection`. `addManualSection` emits markers in the chosen syntax, `addDocblock` emits `<prefix>...` lines when line syntax is configured. `format()` remains opt-in and is unchanged.
- **Exports**: `CommentSyntax` is exported from the package root.
- **README**: new "Generating non-TypeScript files" section with the requested `.gitattributes` example (verified to produce the documented output).
- **CHANGELOG**: the `CommentSyntax` addition is recorded under the existing `[Unreleased]` section so it ships in the next release.

## Backwards compatibility

- Default `CommentSyntax` is `{ kind: "jsdoc" }`; omitting the option is byte-for-byte identical to the previous behaviour. All pre-existing snapshot tests pass without modification.
- Existing locked files continue to verify after the refactor (the JSDoc helpers are only gated on an explicit `syntax` argument; when absent they behave exactly as before).

## Tests

Added parallel tests using `{ kind: "line", prefix: "# " }`:

- **`src/sections/docblock.test.ts`** — round-trips a docblock (get/prepend/remove/create).
- **`src/sections/manual.test.ts`** — creates, extracts, and empties manual sections, including multiple sections and a round-trip.
- **`src/codelock.test.ts`** — `lockCode` emits `# @generated` / `# @generated-editable`, `getCodelockInfo` returns `manualSectionsAllowed: true/false` correctly, `verifyLock` returns `true` after `lockCode`, `false` when the body is edited outside manual sections, `true` when only an editable manual section body changes, and `false` when an uneditable manual section body is tampered with.

### Integration snapshot test

`src/integration.test.ts` drives the public API (`CodeFile`, `CodeBuilder`) end-to-end, writes to a temp directory, and snapshots the on-disk bytes of eight representative generated files. The committed snapshot file at `src/__snapshots__/integration.test.ts.snap` doubles as a catalogue of what files produced by tscodegen look like in practice. Covered examples:

- editable TypeScript class with Prettier formatting and nested manual sections
- uneditable TypeScript constants file
- TypeScript file with a custom lock comment (regeneration instructions)
- regenerating an editable file preserves existing manual section content
- `.gitattributes` with an editable manual section (line, `# ` prefix)
- uneditable shell script (line, `# ` prefix)
- TypeScript file with `// ` docblocks and an editable manual section
- `.gitattributes` regenerated with a human-edited manual section (line, `# ` prefix)

### Verification

- `yarn test` → 94/94 passing, 19 snapshots (Vitest).
- `yarn typecheck` → clean.
- `yarn lint` → clean.
- `yarn build` → clean.
- Manual smoke test of the README `.gitattributes` example produces the documented output and `verify()` returns `true`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cd3642d-6c21-4fc5-a170-cbce5c568299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cd3642d-6c21-4fc5-a170-cbce5c568299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

