### PR TITLE
First-class indentation support (Python, YAML, Makefile, …)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.gitattributes`). The default remains `{ kind: "jsdoc" }`, preserving the
   existing JSDoc/C-style output byte-for-byte.
 - `CommentSyntax` is re-exported from the package root.
+- **`CodeBuilder.indent(amount, fn)`** for generating
+  indentation-sensitive languages (Python, YAML, Makefile, …). Opens a
+  nested builder scope whose ambient indent is the current indent plus
+  `amount`; every emitted line — including manual-section markers and
+  bodies — is prefixed accordingly. Indent scopes compose additively and
+  accept any string (spaces, tabs, mixed).
+- `createManualSection` accepts a new optional `indent` argument for
+  callers who use the helper directly.
 
 ### Changed
+
+- **Manual sections are now stored as semantic (column-0) content.**
+  `extractManualSections` auto-detects each section's indent from the
+  BEGIN marker and dedents every body line uniformly, so round-tripping
+  works cleanly regardless of where a section lives in the file. As part
+  of this:
+  - The previous behaviour was subtly buggy: `.trim()` on the whole
+    captured body only dedented line 1. Multi-line bodies kept the
+    original indent on lines 2+, which surfaced visibly for any consumer
+    that didn't re-run Prettier after extraction. This is now correct.
+  - Manual-section markers must each appear on their own line. The
+    historical regex also matched the single-line pathological form
+    `/* BEGIN MANUAL SECTION k */body/* END MANUAL SECTION */`, which is
+    never emitted by `createManualSection` and is now ignored.
+
+### Breaking
+
+- **Codelock hashes produced prior to this release are no longer valid.**
+  The normalized form consumed by `emptyManualSections` — which is the
+  input to the codelock hash — now preserves the BEGIN marker's indent,
+  and `createManualSection`'s output for non-trivial manual-section
+  inputs also changed (see above). Files locked by earlier versions will
+  fail `verify()` against this release and need to be regenerated.
+- `CodeBuilder` has a new optional third constructor parameter, `indent`.
+  The constructor remains source-compatible for all existing call sites;
+  the default is `""` (no ambient indent).
 
 - **Migrated test runner from Jest to Vitest.** Simpler setup, no `ts-jest` transformer required, and faster runs.
 - Bumped dev dependencies to latest: TypeScript 6.x, ESLint 10.x, `typescript-eslint` 8.x, Prettier 3.8.x, Vitest 4.x, and related tooling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,50 +16,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.gitattributes`). The default remains `{ kind: "jsdoc" }`, preserving the
   existing JSDoc/C-style output byte-for-byte.
 - `CommentSyntax` is re-exported from the package root.
-- **`CodeBuilder.indent(amount, fn)`** for generating
-  indentation-sensitive languages (Python, YAML, Makefile, …). Opens a
-  nested builder scope whose ambient indent is the current indent plus
+- `CodeBuilder.indent(amount, fn)` for generating indentation-sensitive
+  languages (Python, YAML, Terraform, Makefile, …). Opens a nested
+  builder scope whose ambient indent is the current indent plus
   `amount`; every emitted line — including manual-section markers and
-  bodies — is prefixed accordingly. Indent scopes compose additively and
-  accept any string (spaces, tabs, mixed).
+  bodies — is prefixed accordingly. Indent scopes compose additively
+  and accept any string (spaces, tabs, mixed).
 - `createManualSection` accepts a new optional `indent` argument for
   callers who use the helper directly.
+- `CodeBuilder` constructor accepts an optional third `indent` argument
+  (defaults to `""`).
 
 ### Changed
 
-- **Manual sections are now stored as semantic (column-0) content.**
+- Manual sections are now stored as semantic (column-0) content.
   `extractManualSections` auto-detects each section's indent from the
   BEGIN marker and dedents every body line uniformly, so round-tripping
-  works cleanly regardless of where a section lives in the file. As part
-  of this:
-  - The previous behaviour was subtly buggy: `.trim()` on the whole
-    captured body only dedented line 1. Multi-line bodies kept the
-    original indent on lines 2+, which surfaced visibly for any consumer
-    that didn't re-run Prettier after extraction. This is now correct.
-  - Manual-section markers must each appear on their own line. The
-    historical regex also matched the single-line pathological form
-    `/* BEGIN MANUAL SECTION k */body/* END MANUAL SECTION */`, which is
-    never emitted by `createManualSection` and is now ignored.
+  works cleanly regardless of where a section lives in the file. The
+  previous behaviour was subtly buggy: `.trim()` on the whole captured
+  body only dedented line 1, and multi-line bodies kept the original
+  indent on lines 2+.
+- Migrated test runner from Jest to Vitest. Simpler setup, no `ts-jest`
+  transformer required, and faster runs.
+- Bumped dev dependencies to latest: TypeScript 6.x, ESLint 10.x,
+  `typescript-eslint` 8.x, Prettier 3.8.x, Vitest 4.x, and related
+  tooling.
+- ESLint flat config simplified to use `typescript-eslint`'s config
+  helpers and `@vitest/eslint-plugin` in place of `eslint-plugin-jest`.
+- TypeScript target updated from ES2018 to ES2022 to match the current
+  supported Node versions.
+- Dropped the deprecated `codecov` npm uploader; CI now uploads coverage
+  to Codecov via the official `codecov/codecov@5` CircleCI orb, using
+  the `lcov.info` produced by Vitest's v8 coverage.
+- Dropped `@eslint/eslintrc` compat layer.
+- Raised minimum Node.js version to `>=20.18.0`.
 
 ### Breaking
 
-- **Codelock hashes produced prior to this release are no longer valid.**
+- Codelock hashes produced prior to this release are no longer valid.
   The normalized form consumed by `emptyManualSections` — which is the
   input to the codelock hash — now preserves the BEGIN marker's indent,
-  and `createManualSection`'s output for non-trivial manual-section
-  inputs also changed (see above). Files locked by earlier versions will
-  fail `verify()` against this release and need to be regenerated.
-- `CodeBuilder` has a new optional third constructor parameter, `indent`.
-  The constructor remains source-compatible for all existing call sites;
-  the default is `""` (no ambient indent).
-
-- **Migrated test runner from Jest to Vitest.** Simpler setup, no `ts-jest` transformer required, and faster runs.
-- Bumped dev dependencies to latest: TypeScript 6.x, ESLint 10.x, `typescript-eslint` 8.x, Prettier 3.8.x, Vitest 4.x, and related tooling.
-- ESLint flat config simplified to use `typescript-eslint`'s config helpers and `@vitest/eslint-plugin` in place of `eslint-plugin-jest`.
-- TypeScript target updated from ES2018 to ES2022 to match the current supported Node versions.
-- Dropped the deprecated `codecov` npm uploader; CI now uploads coverage to Codecov via the official `codecov/codecov@5` CircleCI orb, using the `lcov.info` produced by Vitest's v8 coverage.
-- Dropped `@eslint/eslintrc` compat layer.
-- Raised minimum Node.js version to `>=20.18.0`.
+  and `createManualSection`'s output for multi-line bodies is now
+  correctly dedented rather than partially dedented. Files locked by
+  earlier versions will fail `verify()` and need to be regenerated.
+- Manual-section markers must each appear on their own line. The
+  historical regex also matched the pathological single-line form
+  `/* BEGIN MANUAL SECTION k */body/* END MANUAL SECTION */`, which is
+  never emitted by `createManualSection` and is now ignored.
 
 ## [0.4.0] - 2026-03-02
 

--- a/README.md
+++ b/README.md
@@ -227,10 +227,10 @@ formats, or any other layout where column position matters.
 
 ### Supported file types by `CommentSyntax`
 
-tscodegen doesn't care what the comment prefix string is, so any
+tscodegen treats the comment prefix as an opaque string, so any
 language whose comments fit one of the supported shapes works out of
-the box. The table below covers the file types most people generating
-code in 2026 would actually target.
+the box. The table below lists the configurations for common target
+file types.
 
 | File type                           | `CommentSyntax`                               |
 | ----------------------------------- | --------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -229,29 +229,26 @@ formats, or any other layout where column position matters.
 
 tscodegen doesn't care what the comment prefix string is, so any
 language whose comments fit one of the supported shapes works out of
-the box. The table below maps common target file types to the
-corresponding `CommentSyntax` config.
+the box. The table below covers the file types most people generating
+code in 2026 would actually target.
 
 | File type                           | `CommentSyntax`                               |
 | ----------------------------------- | --------------------------------------------- |
 | TypeScript / JavaScript / TSX / JSX | `{ kind: "jsdoc" }` (default)                 |
-| Go, Rust, Swift, Kotlin, Dart, Java | `{ kind: "jsdoc" }`                           |
-| C, C++, Objective-C                 | `{ kind: "jsdoc" }`                           |
+| Go, Rust, Swift, Kotlin, Java       | `{ kind: "jsdoc" }`                           |
+| C, C++                              | `{ kind: "jsdoc" }`                           |
 | CSS / SCSS / LESS                   | `{ kind: "jsdoc" }`                           |
-| PHP, Groovy, Jenkinsfile, Protobuf  | `{ kind: "jsdoc" }`                           |
-| TypeScript (line-comment preferred) | `{ kind: "line", prefix: "// " }`             |
-| Python, Ruby, Perl, R, PowerShell   | `{ kind: "line", prefix: "# " }`              |
+| Protobuf                            | `{ kind: "jsdoc" }`                           |
+| TS/JS (line-comment preferred)      | `{ kind: "line", prefix: "// " }`             |
+| Python, Ruby                        | `{ kind: "line", prefix: "# " }`              |
 | Shell / Bash / zsh                  | `{ kind: "line", prefix: "# " }`              |
-| YAML, TOML, Dockerfile, `.env`      | `{ kind: "line", prefix: "# " }`              |
+| YAML, TOML                          | `{ kind: "line", prefix: "# " }`              |
+| Dockerfile, `.env`                  | `{ kind: "line", prefix: "# " }`              |
 | Terraform / HCL, GraphQL            | `{ kind: "line", prefix: "# " }`              |
 | Makefile                            | `{ kind: "line", prefix: "# " }` + tab indent |
 | `.gitattributes`, `.gitignore`      | `{ kind: "line", prefix: "# " }`              |
-| nginx.conf, systemd unit, BUILD     | `{ kind: "line", prefix: "# " }`              |
-| SQL, Haskell, Lua, Elm              | `{ kind: "line", prefix: "-- " }`             |
-| Lisp / Clojure / Scheme, INI        | `{ kind: "line", prefix: "; " }`              |
-| LaTeX, MATLAB, Erlang, Prolog       | `{ kind: "line", prefix: "% " }`              |
-| Fortran 90+                         | `{ kind: "line", prefix: "! " }`              |
-| Visual Basic / VBA                  | `{ kind: "line", prefix: "' " }`              |
+| nginx.conf, systemd unit            | `{ kind: "line", prefix: "# " }`              |
+| SQL                                 | `{ kind: "line", prefix: "-- " }`             |
 
 The Python/YAML/Terraform/Makefile/SQL snapshots in
 `src/__snapshots__/integration.test.ts.snap` are a living catalogue of

--- a/README.md
+++ b/README.md
@@ -222,5 +222,33 @@ re-shifting of nested indents (the `if`/`raise` pair keeps its 4-space
 relative indent).
 
 `indent()` accepts any string — typically spaces or `"\t"` — so it also
-covers Makefile recipes, YAML mappings, INI-like formats, or any other
-layout where column position matters.
+covers Makefile recipes, YAML mappings, Terraform/HCL blocks, INI-like
+formats, or any other layout where column position matters.
+
+Example Terraform fragment (note the manual section buried inside
+`tags = { ... }`, which survives regeneration along with whatever the
+author adds inside it):
+
+```typescript
+new CodeFile("main.tf", { commentSyntax: { kind: "line", prefix: "# " } })
+  .build((b) =>
+    b
+      .addLine('resource "aws_s3_bucket" "logs" {')
+      .indent("  ", (res) =>
+        res
+          .addLine('bucket = "logs"')
+          .addLine("tags = {")
+          .indent("  ", (tags) =>
+            tags
+              .addLine('Name = "logs"')
+              .addManualSection("extra_tags", (m) =>
+                m.addLine('Team = "platform"'),
+              ),
+          )
+          .addLine("}"),
+      )
+      .addLine("}"),
+  )
+  .lock()
+  .saveToFile();
+```

--- a/README.md
+++ b/README.md
@@ -266,31 +266,3 @@ what generated output looks like for each of these.
   docblock. For scripts invoked as executables, either prepend the
   shebang yourself after locking or invoke them via the interpreter
   directly.
-
-Example Terraform fragment (note the manual section buried inside
-`tags = { ... }`, which survives regeneration along with whatever the
-author adds inside it):
-
-```typescript
-new CodeFile("main.tf", { commentSyntax: { kind: "line", prefix: "# " } })
-  .build((b) =>
-    b
-      .addLine('resource "aws_s3_bucket" "logs" {')
-      .indent("  ", (res) =>
-        res
-          .addLine('bucket = "logs"')
-          .addLine("tags = {")
-          .indent("  ", (tags) =>
-            tags
-              .addLine('Name = "logs"')
-              .addManualSection("extra_tags", (m) =>
-                m.addLine('Team = "platform"'),
-              ),
-          )
-          .addLine("}"),
-      )
-      .addLine("}"),
-  )
-  .lock()
-  .saveToFile();
-```

--- a/README.md
+++ b/README.md
@@ -260,9 +260,7 @@ what generated output looks like for each of these.
   to generate JSON alongside other files, either emit a companion
   metadata file or use JSONC (`{ kind: "line", prefix: "// " }`).
 - **XML / HTML / SVG / Markdown / Vue SFCs / MDX** use `<!-- ... -->`
-  wrapping comments, which is not yet expressible in `CommentSyntax`.
-  This is a planned follow-up (a `{ kind: "wrapped"; open, close }`
-  variant).
+  wrapping comments, which is not expressible in `CommentSyntax`.
 - **Shebangs must be line 1.** `lock()` prepends its docblock, so a
   locked shell script's `#!/usr/bin/env bash` ends up below the
   docblock. For scripts invoked as executables, either prepend the

--- a/README.md
+++ b/README.md
@@ -164,3 +164,63 @@ path/to/generated.ts linguist-generated=true
 Everything else works the same: `verify()` detects tampering outside the
 manual sections, `lock()` adds the hash, and `saveToFile()` writes the
 result. Manual-section keys still must be non-empty and whitespace-free.
+
+## Generating indentation-sensitive languages (Python, YAML, Makefile, …)
+
+For languages where indentation is syntactic, use `CodeBuilder.indent(amount, fn)`
+to open a nested scope in which every emitted line (including manual-section
+markers and bodies) is prefixed with `amount`. Indent scopes compose
+additively: `indent("  ", b => b.indent("  ", bb => …))` produces four spaces
+of indent.
+
+```typescript
+new CodeFile("compute.py", { commentSyntax: { kind: "line", prefix: "# " } })
+  .build((b) =>
+    b
+      .addLine("def compute(x: int) -> int:")
+      .indent("    ", (fn) =>
+        fn
+          .addLine("result = x + 1")
+          .addManualSection("postprocess", (m) => m.addLine("return result")),
+      ),
+  )
+  .lock()
+  .saveToFile();
+```
+
+Output:
+
+```python
+# This file is generated with manually editable sections. Only make
+# modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
+# designators.
+#
+# @generated-editable Codelock<<...>>
+
+def compute(x: int) -> int:
+    result = x + 1
+    # BEGIN MANUAL SECTION postprocess
+    return result
+    # END MANUAL SECTION
+```
+
+Manual sections round-trip cleanly across regenerations: the stored body is
+_semantic_ (column-0 content), and the builder reapplies the ambient indent
+on the way out. So a human who edits the section and adds lines at the
+matching indent:
+
+```python
+    # BEGIN MANUAL SECTION postprocess
+    if result > 100:
+        raise ValueError(result)
+    return result
+    # END MANUAL SECTION
+```
+
+will see their edits preserved verbatim after regeneration, with no
+re-shifting of nested indents (the `if`/`raise` pair keeps its 4-space
+relative indent).
+
+`indent()` accepts any string — typically spaces or `"\t"` — so it also
+covers Makefile recipes, YAML mappings, INI-like formats, or any other
+layout where column position matters.

--- a/README.md
+++ b/README.md
@@ -225,6 +225,53 @@ relative indent).
 covers Makefile recipes, YAML mappings, Terraform/HCL blocks, INI-like
 formats, or any other layout where column position matters.
 
+### Supported file types by `CommentSyntax`
+
+tscodegen doesn't care what the comment prefix string is, so any
+language whose comments fit one of the supported shapes works out of
+the box. The table below maps common target file types to the
+corresponding `CommentSyntax` config.
+
+| File type                           | `CommentSyntax`                               |
+| ----------------------------------- | --------------------------------------------- |
+| TypeScript / JavaScript / TSX / JSX | `{ kind: "jsdoc" }` (default)                 |
+| Go, Rust, Swift, Kotlin, Dart, Java | `{ kind: "jsdoc" }`                           |
+| C, C++, Objective-C                 | `{ kind: "jsdoc" }`                           |
+| CSS / SCSS / LESS                   | `{ kind: "jsdoc" }`                           |
+| PHP, Groovy, Jenkinsfile, Protobuf  | `{ kind: "jsdoc" }`                           |
+| TypeScript (line-comment preferred) | `{ kind: "line", prefix: "// " }`             |
+| Python, Ruby, Perl, R, PowerShell   | `{ kind: "line", prefix: "# " }`              |
+| Shell / Bash / zsh                  | `{ kind: "line", prefix: "# " }`              |
+| YAML, TOML, Dockerfile, `.env`      | `{ kind: "line", prefix: "# " }`              |
+| Terraform / HCL, GraphQL            | `{ kind: "line", prefix: "# " }`              |
+| Makefile                            | `{ kind: "line", prefix: "# " }` + tab indent |
+| `.gitattributes`, `.gitignore`      | `{ kind: "line", prefix: "# " }`              |
+| nginx.conf, systemd unit, BUILD     | `{ kind: "line", prefix: "# " }`              |
+| SQL, Haskell, Lua, Elm              | `{ kind: "line", prefix: "-- " }`             |
+| Lisp / Clojure / Scheme, INI        | `{ kind: "line", prefix: "; " }`              |
+| LaTeX, MATLAB, Erlang, Prolog       | `{ kind: "line", prefix: "% " }`              |
+| Fortran 90+                         | `{ kind: "line", prefix: "! " }`              |
+| Visual Basic / VBA                  | `{ kind: "line", prefix: "' " }`              |
+
+The Python/YAML/Terraform/Makefile/SQL snapshots in
+`src/__snapshots__/integration.test.ts.snap` are a living catalogue of
+what generated output looks like for each of these.
+
+### Known limitations
+
+- **JSON has no comment syntax**, so it cannot be locked. If you need
+  to generate JSON alongside other files, either emit a companion
+  metadata file or use JSONC (`{ kind: "line", prefix: "// " }`).
+- **XML / HTML / SVG / Markdown / Vue SFCs / MDX** use `<!-- ... -->`
+  wrapping comments, which is not yet expressible in `CommentSyntax`.
+  This is a planned follow-up (a `{ kind: "wrapped"; open, close }`
+  variant).
+- **Shebangs must be line 1.** `lock()` prepends its docblock, so a
+  locked shell script's `#!/usr/bin/env bash` ends up below the
+  docblock. For scripts invoked as executables, either prepend the
+  shebang yourself after locking or invoke them via the interpreter
+  directly.
+
 Example Terraform fragment (note the manual section buried inside
 `tags = { ... }`, which survives regeneration along with whatever the
 author adds inside it):

--- a/src/CodeBuilder.test.ts
+++ b/src/CodeBuilder.test.ts
@@ -209,6 +209,13 @@ in the block.
         .toString();
       expect(output).toBe("root\n\tchild\n");
     });
+
+    test("should only apply indent at the start of a line when `add` is called repeatedly mid-line", () => {
+      const output = new CodeBuilder({})
+        .indent("  ", (b) => b.add("foo").add("bar").addLine(" baz"))
+        .toString();
+      expect(output).toBe("  foobar baz\n");
+    });
   });
 
   describe(CodeBuilder.prototype.format, () => {

--- a/src/CodeBuilder.test.ts
+++ b/src/CodeBuilder.test.ts
@@ -262,6 +262,20 @@ in the block.
         removeDir(tempDir);
       }
     });
+
+    test("should re-synchronize the at-line-start flag after formatting", () => {
+      // Regression test: before the fix, calling format() on a builder
+      // with ambient indent left a stale atLineStart from the pre-format
+      // state. A subsequent addLine() then skipped or misapplied the
+      // ambient indent depending on whether the last pre-format write
+      // ended with a newline.
+      const output = new CodeBuilder({}, { kind: "jsdoc" }, "  ")
+        .add("const x = 1;") // trailing char is ';', atLineStart = false
+        .format() // prettier normalizes to "const x = 1;\n"
+        .addLine("const y = 2;") // should land indented under ambient
+        .toString();
+      expect(output).toBe("const x = 1;\n  const y = 2;\n");
+    });
   });
 
   test("should work", () => {

--- a/src/CodeBuilder.test.ts
+++ b/src/CodeBuilder.test.ts
@@ -136,6 +136,81 @@ in the block.
     });
   });
 
+  describe(CodeBuilder.prototype.indent, () => {
+    test("should prefix each line of nested output with the given indent", () => {
+      const output = new CodeBuilder({})
+        .addLine("class Foo:")
+        .indent("    ", (b) => b.addLine("def bar(self):").addLine("    pass"))
+        .toString();
+      expect(output).toBe(`class Foo:\n    def bar(self):\n        pass\n`);
+    });
+
+    test("should leave empty lines unindented (no trailing whitespace)", () => {
+      const output = new CodeBuilder({})
+        .addLine("header")
+        .indent("  ", (b) => b.addLine("first").addLine().addLine("third"))
+        .toString();
+      expect(output).toBe("header\n  first\n\n  third\n");
+    });
+
+    test("should compose nested indent scopes additively", () => {
+      const output = new CodeBuilder({})
+        .addLine("outer")
+        .indent("  ", (b) =>
+          b.addLine("depth 1").indent("  ", (bb) => bb.addLine("depth 2")),
+        )
+        .toString();
+      expect(output).toBe("outer\n  depth 1\n    depth 2\n");
+    });
+
+    test("should indent manual section markers and body when nested", () => {
+      const output = new CodeBuilder({}, { kind: "line", prefix: "# " })
+        .addLine("def compute(x):")
+        .indent("    ", (b) =>
+          b
+            .addLine("result = x + 1")
+            .addManualSection("postprocess", (m) => m.addLine("return result")),
+        )
+        .toString();
+      expect(output).toBe(
+        `def compute(x):\n    result = x + 1\n    # BEGIN MANUAL SECTION postprocess\n    return result\n    # END MANUAL SECTION\n`,
+      );
+    });
+
+    test("should re-indent an existing manual section body when regenerating inside an indent scope", () => {
+      const builder = new CodeBuilder(
+        { body: "if x:\n    return 42\nreturn 0" },
+        { kind: "line", prefix: "# " },
+      );
+      const output = builder
+        .addLine("def f():")
+        .indent("    ", (b) =>
+          b.addManualSection("body", (m) => m.addLine("placeholder")),
+        )
+        .toString();
+      expect(output).toBe(
+        `def f():\n    # BEGIN MANUAL SECTION body\n    if x:\n        return 42\n    return 0\n    # END MANUAL SECTION\n`,
+      );
+    });
+
+    test("should propagate hasManualSections out of nested indent scope", () => {
+      const builder = new CodeBuilder({});
+      expect(builder.hasManualSections()).toBe(false);
+      builder.indent("  ", (b) =>
+        b.addManualSection("key", (m) => m.addLine("body")),
+      );
+      expect(builder.hasManualSections()).toBe(true);
+    });
+
+    test("should accept tab characters as indent", () => {
+      const output = new CodeBuilder({})
+        .addLine("root")
+        .indent("\t", (b) => b.addLine("child"))
+        .toString();
+      expect(output).toBe("root\n\tchild\n");
+    });
+  });
+
   describe(CodeBuilder.prototype.format, () => {
     test("should resolve prettier config from cwd using a ts filepath", () => {
       const originalCwd = process.cwd();

--- a/src/CodeBuilder.ts
+++ b/src/CodeBuilder.ts
@@ -7,31 +7,80 @@ import { CommentSyntax, DEFAULT_COMMENT_SYNTAX } from "./types/CommentSyntax";
 export class CodeBuilder {
   #gennedCode = "";
   #hasManualSections = false;
+  /** Whether the next emitted character will land at the start of a line. */
+  #atLineStart = true;
 
   readonly #existingManualSections: ManualSectionMap;
   readonly #commentSyntax: CommentSyntax;
+  readonly #indent: string;
 
   constructor(
     manualSections: ManualSectionMap,
     commentSyntax: CommentSyntax = DEFAULT_COMMENT_SYNTAX,
+    indent = "",
   ) {
     this.#existingManualSections = manualSections;
     this.#commentSyntax = commentSyntax;
+    this.#indent = indent;
   }
 
   /**
-   * Simply appends `code`.
+   * Append `code` verbatim without applying this builder's ambient indent.
+   * Used only to splice in output from a child builder whose indent has
+   * already been baked in (i.e. children created by `indent()`).
+   */
+  #appendRaw(code: string): void {
+    if (code.length === 0) {
+      return;
+    }
+    this.#gennedCode += code;
+    this.#atLineStart = code.endsWith("\n");
+  }
+
+  /**
+   * Append `code`, applying this builder's ambient indent to every new line.
+   *
+   * Empty lines are emitted without the indent prefix so we never produce
+   * trailing whitespace on blank lines.
+   */
+  #appendIndented(code: string): void {
+    if (this.#indent.length === 0) {
+      this.#appendRaw(code);
+      return;
+    }
+    const pieces = code.split("\n");
+    for (let i = 0; i < pieces.length; i++) {
+      const piece = pieces[i];
+      const isLast = i === pieces.length - 1;
+      if (piece.length > 0) {
+        if (this.#atLineStart) {
+          this.#gennedCode += this.#indent;
+        }
+        this.#gennedCode += piece;
+        this.#atLineStart = false;
+      }
+      if (!isLast) {
+        this.#gennedCode += "\n";
+        this.#atLineStart = true;
+      }
+    }
+  }
+
+  /**
+   * Appends `code`, respecting any ambient indent from an enclosing
+   * `indent()` scope.
    */
   add(code: string): this {
-    this.#gennedCode += code;
+    this.#appendIndented(code);
     return this;
   }
 
   /**
-   * Appends `code` and a newline. Call without arguments to insert a newline.
+   * Appends `code` and a newline. Call without arguments to insert a blank
+   * line. Respects any ambient indent from an enclosing `indent()` scope.
    */
   addLine(code = ""): this {
-    this.#gennedCode += code + "\n";
+    this.#appendIndented(code + "\n");
     return this;
   }
 
@@ -46,7 +95,40 @@ export class CodeBuilder {
   }
 
   /**
+   * Runs `nested` in a child builder whose ambient indent is the current
+   * indent plus `amount`. Every line emitted by the child is prefixed with
+   * `amount` on top of whatever indent this builder already has.
+   *
+   * Indent scopes compose: `b.indent("  ", (b) => b.indent("  ", ...))`
+   * produces lines indented by four spaces.
+   *
+   * @param amount Whitespace added to the current indent for the duration of
+   * `nested` (typically a run of spaces or tabs, e.g. `"    "` or `"\t"`).
+   * @param nested A function that uses the child builder to emit code.
+   */
+  indent(
+    amount: string,
+    nested: (indentedBuilder: CodeBuilder) => CodeBuilder,
+  ): this {
+    const nestedBuilder = nested(
+      new CodeBuilder(
+        this.#existingManualSections,
+        this.#commentSyntax,
+        this.#indent + amount,
+      ),
+    );
+    this.#hasManualSections =
+      this.#hasManualSections || nestedBuilder.hasManualSections();
+    this.#appendRaw(nestedBuilder.toString());
+    return this;
+  }
+
+  /**
    * Add a block of code, i.e. code with braces around them.
+   *
+   * The block body is built by a nested builder starting at column 0; the
+   * parent's ambient indent is applied uniformly when its output is
+   * spliced back in.
    *
    * @param codeBeforeBlock Code before the block's `{`, e.g. `if (a === b)`
    * @param blockBuilder A function that uses `blockBuilder` to build the code
@@ -71,9 +153,17 @@ export class CodeBuilder {
    * Add a section of code that can be manually edited. The section will be
    * surrounded by "BEGIN MANUAL SECTION" and "END MANUAL SECTION" designators.
    *
+   * The section body is built by a nested builder at column 0 (so that
+   * existing stored section content, which is always semantic, can be
+   * spliced in without reshifting). The parent's ambient indent is applied
+   * uniformly to both markers and the body at emit time, so manual sections
+   * can be placed inside an `indent()` scope and still round-trip cleanly
+   * across regenerations.
+   *
    * @param sectionKey An identifier for this manual section.
-   * @param blockBuilder A function that uses `blockBuilder` to build the code
-   * in the block, if no existing manual section with `sectionKey` is stored.
+   * @param sectionBuilder A function that uses a child builder to build the
+   * code in the block, if no existing manual section with `sectionKey` is
+   * stored.
    */
   addManualSection(
     sectionKey: string,

--- a/src/CodeBuilder.ts
+++ b/src/CodeBuilder.ts
@@ -203,6 +203,12 @@ export class CodeBuilder {
       ...options,
       parser: "typescript",
     });
+    // Resynchronize the line-start flag with the newly-installed code so
+    // subsequent add()/addLine() calls apply the ambient indent correctly.
+    // Prettier's output ends with "\n" when non-empty; treat empty output
+    // as also being at line start.
+    this.#atLineStart =
+      this.#gennedCode.length === 0 || this.#gennedCode.endsWith("\n");
     return this;
   }
 

--- a/src/__snapshots__/codelock.test.ts.snap
+++ b/src/__snapshots__/codelock.test.ts.snap
@@ -7,7 +7,7 @@ exports[`lockCode > editable files > should interpolate provided content 1`] = `
  * designators.
  * CUSTOM LINE 1
  * CUSTOM LINE 2
- * @generated-editable Codelock<<VZ4MZwQh3kgACluPomV+XBbiKqmafUfq>>
+ * @generated-editable Codelock<<SZOHkis46G+poAie7wLZwJjvgG/PEyVm>>
  */
 
 interface CodelockInfo {
@@ -24,7 +24,7 @@ exports[`lockCode > editable files > should prepend file docblock with consisten
  * modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
  * designators.
  *
- * @generated-editable Codelock<<VZ4MZwQh3kgACluPomV+XBbiKqmafUfq>>
+ * @generated-editable Codelock<<SZOHkis46G+poAie7wLZwJjvgG/PEyVm>>
  */
 
 interface CodelockInfo {

--- a/src/__snapshots__/integration.test.ts.snap
+++ b/src/__snapshots__/integration.test.ts.snap
@@ -84,6 +84,29 @@ def compute(x: int) -> int:
 "
 `;
 
+exports[`integration: generated file examples > SQL schema with manual section inside a CREATE TABLE column list 1`] = `
+"-- This file is generated with manually editable sections. Only make
+-- modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
+-- designators.
+--
+-- @generated-editable Codelock<<qmhkvK+QHgb0QcvyyZE0Yn3hWQMMqfrd>>
+
+CREATE TABLE users (
+  id          UUID PRIMARY KEY,
+  email       TEXT NOT NULL,
+  created_at  TIMESTAMP DEFAULT now(),
+  -- BEGIN MANUAL SECTION extra_columns
+  -- Project-specific columns go below. They survive
+  -- regeneration.
+  team_id     INTEGER REFERENCES teams(id),
+  last_login  TIMESTAMP
+  -- END MANUAL SECTION
+);
+
+CREATE INDEX users_email_idx ON users (email);
+"
+`;
+
 exports[`integration: generated file examples > Terraform main.tf with manual sections inside nested HCL blocks 1`] = `
 "# This file is generated with manually editable sections. Only make
 # modifications between BEGIN MANUAL SECTION and END MANUAL SECTION

--- a/src/__snapshots__/integration.test.ts.snap
+++ b/src/__snapshots__/integration.test.ts.snap
@@ -331,6 +331,38 @@ export class Greeter {
 "
 `;
 
+exports[`integration: generated file examples > regenerating at a deeper indent shifts the whole manual section (markers + body + nested indents) 1`] = `
+"# This file is generated with manually editable sections. Only make
+# modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
+# designators.
+#
+# @generated-editable Codelock<<x+SkYLxt2TlWWx2YuUOKDCv6QkCSZj5c>>
+
+class Bar:
+    def foo(self):
+        x = 1
+        # BEGIN MANUAL SECTION body
+        if x > 0:
+            return x
+        return 0
+        # END MANUAL SECTION
+"
+`;
+
+exports[`integration: generated file examples > regenerating at a shallower indent un-shifts the whole manual section 1`] = `
+"# This file is generated with manually editable sections. Only make
+# modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
+# designators.
+#
+# @generated-editable Codelock<<CW9HKidpI5Q3IhPtbAwboG7aeJzyxbqD>>
+
+# BEGIN MANUAL SECTION body
+a = 1
+b = 2
+# END MANUAL SECTION
+"
+`;
+
 exports[`integration: generated file examples > uneditable TypeScript constants file 1`] = `
 "/**
  * This file is generated. Do not modify it manually.

--- a/src/__snapshots__/integration.test.ts.snap
+++ b/src/__snapshots__/integration.test.ts.snap
@@ -84,6 +84,73 @@ def compute(x: int) -> int:
 "
 `;
 
+exports[`integration: generated file examples > Terraform main.tf with manual sections inside nested HCL blocks 1`] = `
+"# This file is generated with manually editable sections. Only make
+# modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
+# designators.
+#
+# Regenerate with: npm run generate:terraform
+#
+# @generated-editable Codelock<<vZC7TYQw86Q7jvlILXkvO6Pxdwio09Xz>>
+
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "logs" {
+  bucket = "acme-app-logs-\${var.environment}"
+
+  lifecycle_rule {
+    enabled = true
+    expiration {
+      days = 90
+    }
+  }
+
+  tags = {
+    Name        = "acme-app-logs"
+    Environment = var.environment
+    # BEGIN MANUAL SECTION extra_tags
+    # Add team-specific tags below; they survive regeneration.
+    Team        = "platform"
+    CostCenter  = "eng-infra-42"
+    # END MANUAL SECTION
+  }
+}
+
+# BEGIN MANUAL SECTION extra_resources
+# Define additional resources here. They are preserved across regenerations.
+# END MANUAL SECTION
+"
+`;
+
+exports[`integration: generated file examples > Terraform: regenerating preserves an indented manual section when a human adds tags 1`] = `
+"# This file is generated with manually editable sections. Only make
+# modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
+# designators.
+#
+# @generated-editable Codelock<<pX2rGIO3dBwyOz2BOHKTmuZu30II8x6r>>
+
+resource "aws_s3_bucket" "logs" {
+  bucket = "logs"
+  tags = {
+    Name = "logs"
+    # BEGIN MANUAL SECTION extra_tags
+    Team        = "platform"
+    CostCenter  = "eng-infra-42"
+    ManagedBy   = terraform.workspace
+    # END MANUAL SECTION
+  }
+}
+"
+`;
+
 exports[`integration: generated file examples > TypeScript file with a custom lock comment (regeneration instructions) 1`] = `
 "/**
  * This file is generated. Do not modify it manually.

--- a/src/__snapshots__/integration.test.ts.snap
+++ b/src/__snapshots__/integration.test.ts.snap
@@ -1,5 +1,89 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`integration: generated file examples > Makefile with tab-indented recipe and a manual section 1`] = `
+"# This file is generated with manually editable sections. Only make
+# modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
+# designators.
+#
+# @generated-editable Codelock<<+Lji5zHg7CuSEpBrzViGEvF1HLfjtRCY>>
+
+.PHONY: build test
+
+build:
+	yarn install
+	yarn build
+	# BEGIN MANUAL SECTION build_postprocess
+	@echo 'customize your build steps here'
+	# END MANUAL SECTION
+"
+`;
+
+exports[`integration: generated file examples > Python class with manual sections at two indentation levels 1`] = `
+"# This file is generated with manually editable sections. Only make
+# modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
+# designators.
+#
+# @generated-editable Codelock<<A+yb9qGMMyY91CxkelWt1ajOEgNmY1Wx>>
+
+from dataclasses import dataclass
+
+# BEGIN MANUAL SECTION custom_imports
+# END MANUAL SECTION
+
+@dataclass
+class User:
+    id: str
+    email: str
+
+    def greet(self) -> str:
+        # BEGIN MANUAL SECTION greet_body
+        return f"Hello, {self.email}!"
+        # END MANUAL SECTION
+"
+`;
+
+exports[`integration: generated file examples > Python module with manual section inside a function body 1`] = `
+"# This file is generated with manually editable sections. Only make
+# modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
+# designators.
+#
+# Regenerate with: python -m tools.codegen compute
+#
+# @generated-editable Codelock<<5gA9/0KxrIFK6Nwo83emTUCsOkBZ3TJf>>
+
+from typing import Iterable
+
+DEFAULT_FACTOR = 1.5
+
+def compute(values: Iterable[float]) -> float:
+    """Compute a weighted sum of values."""
+    total = sum(values) * DEFAULT_FACTOR
+    # BEGIN MANUAL SECTION postprocess
+    # Project-specific adjustments go here.
+    if total > 1000:
+        total = round(total, 2)
+    return total
+    # END MANUAL SECTION
+"
+`;
+
+exports[`integration: generated file examples > Python: regenerating preserves an indented manual section when a human adds lines 1`] = `
+"# This file is generated with manually editable sections. Only make
+# modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
+# designators.
+#
+# @generated-editable Codelock<<TuyOTuNTIOpFTmT7RxtkrT4R9Z2eJemT>>
+
+def compute(x: int) -> int:
+    result = x + 1
+    # BEGIN MANUAL SECTION postprocess
+    if result > 100:
+        raise ValueError(result)
+    return result
+    # END MANUAL SECTION
+"
+`;
+
 exports[`integration: generated file examples > TypeScript file with a custom lock comment (regeneration instructions) 1`] = `
 "/**
  * This file is generated. Do not modify it manually.
@@ -20,13 +104,39 @@ export interface User {
 "
 `;
 
+exports[`integration: generated file examples > YAML docker-compose fragment with manual section inside a nested mapping 1`] = `
+"# This file is generated with manually editable sections. Only make
+# modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
+# designators.
+#
+# @generated-editable Codelock<<Z4GkabYQREpOYIewuR9Yp4bKabytm0ue>>
+
+version: '3.9'
+
+services:
+  web:
+    image: myapp:latest
+    ports:
+      - '8080:8080'
+    # BEGIN MANUAL SECTION web-env
+    environment:
+      - NODE_ENV=production
+      - FEATURE_FLAG=off
+    # END MANUAL SECTION
+  db:
+    image: postgres:15
+    # BEGIN MANUAL SECTION db-env
+    # END MANUAL SECTION
+"
+`;
+
 exports[`integration: generated file examples > editable TypeScript class with manual sections and Prettier formatting 1`] = `
 "/**
  * This file is generated with manually editable sections. Only make
  * modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
  * designators.
  *
- * @generated-editable Codelock<<Qe8LJaSFM2Z2LXSgccvK93WyrqNOc3sp>>
+ * @generated-editable Codelock<<WTRrh4ZJAwBLR98AreqT0n/RgCduvnQm>>
  */
 
 import path from "path";
@@ -115,7 +225,7 @@ exports[`integration: generated file examples > regenerating an editable file pr
  * modifications between BEGIN MANUAL SECTION and END MANUAL SECTION
  * designators.
  *
- * @generated-editable Codelock<<qtt9w2cPNbqw17quFBDPaw3IcVR/xvVt>>
+ * @generated-editable Codelock<<1K9QcroETq3CFtoqioMQnTNs6Kmz7I24>>
  */
 
 export class Greeter {

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -253,4 +253,168 @@ describe("integration: generated file examples", () => {
 
     expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
   });
+
+  test("Python module with manual section inside a function body", () => {
+    const filePath = path.join(tmpDir, "compute.py");
+    new CodeFile(filePath, {
+      commentSyntax: { kind: "line", prefix: "# " },
+    })
+      .build((b) =>
+        b
+          .addLine("from typing import Iterable")
+          .addLine()
+          .addLine("DEFAULT_FACTOR = 1.5")
+          .addLine()
+          .addLine("def compute(values: Iterable[float]) -> float:")
+          .indent("    ", (fn) =>
+            fn
+              .addLine('"""Compute a weighted sum of values."""')
+              .addLine("total = sum(values) * DEFAULT_FACTOR")
+              .addManualSection("postprocess", (m) =>
+                m
+                  .addLine("# Project-specific adjustments go here.")
+                  .addLine("if total > 1000:")
+                  .indent("    ", (branch) =>
+                    branch.addLine("total = round(total, 2)"),
+                  )
+                  .addLine("return total"),
+              ),
+          ),
+      )
+      .lock("\nRegenerate with: python -m tools.codegen compute\n")
+      .saveToFile();
+    expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
+  });
+
+  test("Python class with manual sections at two indentation levels", () => {
+    const filePath = path.join(tmpDir, "user.py");
+    new CodeFile(filePath, {
+      commentSyntax: { kind: "line", prefix: "# " },
+    })
+      .build((b) =>
+        b
+          .addLine("from dataclasses import dataclass")
+          .addLine()
+          .addManualSection("custom_imports", (m) => m)
+          .addLine()
+          .addLine("@dataclass")
+          .addLine("class User:")
+          .indent("    ", (cls) =>
+            cls
+              .addLine("id: str")
+              .addLine("email: str")
+              .addLine()
+              .addLine("def greet(self) -> str:")
+              .indent("    ", (fn) =>
+                fn.addManualSection("greet_body", (m) =>
+                  m.addLine('return f"Hello, {self.email}!"'),
+                ),
+              ),
+          ),
+      )
+      .lock()
+      .saveToFile();
+    expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
+  });
+
+  test("Python: regenerating preserves an indented manual section when a human adds lines", () => {
+    const filePath = path.join(tmpDir, "compute.py");
+    const syntax = { kind: "line" as const, prefix: "# " };
+
+    const writeInitial = () =>
+      new CodeFile(filePath, { commentSyntax: syntax })
+        .build((b) =>
+          b
+            .addLine("def compute(x: int) -> int:")
+            .indent("    ", (fn) =>
+              fn
+                .addLine("result = x + 1")
+                .addManualSection("postprocess", (m) =>
+                  m.addLine("return result"),
+                ),
+            ),
+        )
+        .lock()
+        .saveToFile();
+
+    writeInitial();
+
+    // Human edits inside the manual section, matching the Python indent.
+    const initial = fs.readFileSync(filePath, "utf-8");
+    const edited = initial.replace(
+      "    return result",
+      "    if result > 100:\n        raise ValueError(result)\n    return result",
+    );
+    fs.writeFileSync(filePath, edited, "utf-8");
+
+    // Regenerate with the same builder.
+    writeInitial();
+
+    expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
+  });
+
+  test("YAML docker-compose fragment with manual section inside a nested mapping", () => {
+    const filePath = path.join(tmpDir, "docker-compose.yml");
+    new CodeFile(filePath, {
+      commentSyntax: { kind: "line", prefix: "# " },
+    })
+      .build((b) =>
+        b
+          .addLine("version: '3.9'")
+          .addLine()
+          .addLine("services:")
+          .indent("  ", (services) =>
+            services
+              .addLine("web:")
+              .indent("  ", (web) =>
+                web
+                  .addLine("image: myapp:latest")
+                  .addLine("ports:")
+                  .indent("  ", (ports) => ports.addLine("- '8080:8080'"))
+                  .addManualSection("web-env", (m) =>
+                    m
+                      .addLine("environment:")
+                      .indent("  ", (env) =>
+                        env
+                          .addLine("- NODE_ENV=production")
+                          .addLine("- FEATURE_FLAG=off"),
+                      ),
+                  ),
+              )
+              .addLine("db:")
+              .indent("  ", (db) =>
+                db
+                  .addLine("image: postgres:15")
+                  .addManualSection("db-env", (m) => m),
+              ),
+          ),
+      )
+      .lock()
+      .saveToFile();
+    expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
+  });
+
+  test("Makefile with tab-indented recipe and a manual section", () => {
+    const filePath = path.join(tmpDir, "Makefile");
+    new CodeFile(filePath, {
+      commentSyntax: { kind: "line", prefix: "# " },
+    })
+      .build((b) =>
+        b
+          .addLine(".PHONY: build test")
+          .addLine()
+          .addLine("build:")
+          .indent("\t", (recipe) =>
+            recipe
+              .addLine("yarn install")
+              .addLine("yarn build")
+              .addManualSection("build_postprocess", (m) =>
+                m.addLine("@echo 'customize your build steps here'"),
+              ),
+          ),
+      )
+      .lock()
+      .saveToFile();
+    expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
+  });
 });

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -511,6 +511,36 @@ describe("integration: generated file examples", () => {
     expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
   });
 
+  test("SQL schema with manual section inside a CREATE TABLE column list", () => {
+    const filePath = path.join(tmpDir, "users.sql");
+    new CodeFile(filePath, {
+      commentSyntax: { kind: "line", prefix: "-- " },
+    })
+      .build((b) =>
+        b
+          .addLine("CREATE TABLE users (")
+          .indent("  ", (cols) =>
+            cols
+              .addLine("id          UUID PRIMARY KEY,")
+              .addLine("email       TEXT NOT NULL,")
+              .addLine("created_at  TIMESTAMP DEFAULT now(),")
+              .addManualSection("extra_columns", (m) =>
+                m
+                  .addLine("-- Project-specific columns go below. They survive")
+                  .addLine("-- regeneration.")
+                  .addLine("team_id     INTEGER REFERENCES teams(id),")
+                  .addLine("last_login  TIMESTAMP"),
+              ),
+          )
+          .addLine(");")
+          .addLine()
+          .addLine("CREATE INDEX users_email_idx ON users (email);"),
+      )
+      .lock()
+      .saveToFile();
+    expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
+  });
+
   test("Makefile with tab-indented recipe and a manual section", () => {
     const filePath = path.join(tmpDir, "Makefile");
     new CodeFile(filePath, {

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -394,6 +394,123 @@ describe("integration: generated file examples", () => {
     expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
   });
 
+  test("Terraform main.tf with manual sections inside nested HCL blocks", () => {
+    const filePath = path.join(tmpDir, "main.tf");
+    new CodeFile(filePath, {
+      commentSyntax: { kind: "line", prefix: "# " },
+    })
+      .build((b) =>
+        b
+          .addLine("terraform {")
+          .indent("  ", (tf) =>
+            tf
+              .addLine('required_version = ">= 1.6.0"')
+              .addLine("required_providers {")
+              .indent("  ", (rp) =>
+                rp
+                  .addLine("aws = {")
+                  .indent("  ", (aws) =>
+                    aws
+                      .addLine('source  = "hashicorp/aws"')
+                      .addLine('version = "~> 5.0"'),
+                  )
+                  .addLine("}"),
+              )
+              .addLine("}"),
+          )
+          .addLine("}")
+          .addLine()
+          .addLine('resource "aws_s3_bucket" "logs" {')
+          .indent("  ", (res) =>
+            res
+              .addLine('bucket = "acme-app-logs-${var.environment}"')
+              .addLine()
+              .addLine("lifecycle_rule {")
+              .indent("  ", (lc) =>
+                lc
+                  .addLine("enabled = true")
+                  .addLine("expiration {")
+                  .indent("  ", (exp) => exp.addLine("days = 90"))
+                  .addLine("}"),
+              )
+              .addLine("}")
+              .addLine()
+              .addLine("tags = {")
+              .indent("  ", (tags) =>
+                tags
+                  .addLine('Name        = "acme-app-logs"')
+                  .addLine("Environment = var.environment")
+                  .addManualSection("extra_tags", (m) =>
+                    m
+                      .addLine(
+                        "# Add team-specific tags below; they survive regeneration.",
+                      )
+                      .addLine('Team        = "platform"')
+                      .addLine('CostCenter  = "eng-infra-42"'),
+                  ),
+              )
+              .addLine("}"),
+          )
+          .addLine("}")
+          .addLine()
+          .addManualSection("extra_resources", (m) =>
+            m.addLine(
+              "# Define additional resources here. They are preserved across regenerations.",
+            ),
+          ),
+      )
+      .lock("\nRegenerate with: npm run generate:terraform\n")
+      .saveToFile();
+    expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
+  });
+
+  test("Terraform: regenerating preserves an indented manual section when a human adds tags", () => {
+    const filePath = path.join(tmpDir, "main.tf");
+    const syntax = { kind: "line" as const, prefix: "# " };
+
+    const writeInitial = () =>
+      new CodeFile(filePath, { commentSyntax: syntax })
+        .build((b) =>
+          b
+            .addLine('resource "aws_s3_bucket" "logs" {')
+            .indent("  ", (res) =>
+              res
+                .addLine('bucket = "logs"')
+                .addLine("tags = {")
+                .indent("  ", (tags) =>
+                  tags
+                    .addLine('Name = "logs"')
+                    .addManualSection("extra_tags", (m) =>
+                      m.addLine('Team = "platform"'),
+                    ),
+                )
+                .addLine("}"),
+            )
+            .addLine("}"),
+        )
+        .lock()
+        .saveToFile();
+
+    writeInitial();
+
+    // Human edits inside the manual section at the matching (4-space) indent.
+    const initial = fs.readFileSync(filePath, "utf-8");
+    const edited = initial.replace(
+      '    Team = "platform"',
+      [
+        '    Team        = "platform"',
+        '    CostCenter  = "eng-infra-42"',
+        "    ManagedBy   = terraform.workspace",
+      ].join("\n"),
+    );
+    fs.writeFileSync(filePath, edited, "utf-8");
+
+    // Regenerate with the same builder.
+    writeInitial();
+
+    expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
+  });
+
   test("Makefile with tab-indented recipe and a manual section", () => {
     const filePath = path.join(tmpDir, "Makefile");
     new CodeFile(filePath, {

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -511,6 +511,83 @@ describe("integration: generated file examples", () => {
     expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
   });
 
+  test("regenerating at a deeper indent shifts the whole manual section (markers + body + nested indents)", () => {
+    const filePath = path.join(tmpDir, "module.py");
+    const syntax = { kind: "line" as const, prefix: "# " };
+
+    // v1: the section lives inside a top-level function (1 indent level).
+    new CodeFile(filePath, { commentSyntax: syntax })
+      .build((b) =>
+        b.addLine("def foo():").indent("    ", (fn) =>
+          fn.addLine("x = 1").addManualSection("body", (m) =>
+            m
+              .addLine("if x > 0:")
+              .indent("    ", (branch) => branch.addLine("return x"))
+              .addLine("return 0"),
+          ),
+        ),
+      )
+      .lock()
+      .saveToFile();
+
+    // v2: the generator now wraps that function in a class, moving the
+    // section to 2 indent levels. The whole section — BEGIN marker, body
+    // lines, the relative indent on `return x`, and END marker — should
+    // shift uniformly to the new depth.
+    new CodeFile(filePath, { commentSyntax: syntax })
+      .build((b) =>
+        b.addLine("class Bar:").indent("    ", (cls) =>
+          cls.addLine("def foo(self):").indent("    ", (fn) =>
+            fn.addLine("x = 1").addManualSection("body", (m) =>
+              m
+                .addLine("if x > 0:")
+                .indent("    ", (branch) => branch.addLine("return x"))
+                .addLine("return 0"),
+            ),
+          ),
+        ),
+      )
+      .lock()
+      .saveToFile();
+
+    expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
+  });
+
+  test("regenerating at a shallower indent un-shifts the whole manual section", () => {
+    const filePath = path.join(tmpDir, "module.py");
+    const syntax = { kind: "line" as const, prefix: "# " };
+
+    // v1: section is 2 levels deep (inside a method inside a class).
+    new CodeFile(filePath, { commentSyntax: syntax })
+      .build((b) =>
+        b
+          .addLine("class Outer:")
+          .indent("    ", (cls) =>
+            cls
+              .addLine("def method(self):")
+              .indent("    ", (fn) =>
+                fn.addManualSection("body", (m) =>
+                  m.addLine("a = 1").addLine("b = 2"),
+                ),
+              ),
+          ),
+      )
+      .lock()
+      .saveToFile();
+
+    // v2: the generator has been changed to emit the section at the top
+    // level; the section should come out at column 0, with no stale indent
+    // left behind on the markers or body.
+    new CodeFile(filePath, { commentSyntax: syntax })
+      .build((b) =>
+        b.addManualSection("body", (m) => m.addLine("a = 1").addLine("b = 2")),
+      )
+      .lock()
+      .saveToFile();
+
+    expect(fs.readFileSync(filePath, "utf-8")).toMatchSnapshot();
+  });
+
   test("SQL schema with manual section inside a CREATE TABLE column list", () => {
     const filePath = path.join(tmpDir, "users.sql");
     new CodeFile(filePath, {

--- a/src/sections/manual.test.ts
+++ b/src/sections/manual.test.ts
@@ -90,17 +90,20 @@ describe(extractManualSections, () => {
     ).toEqual({});
   });
 
-  test("should extract single line manual section", () => {
+  test("should ignore pathological single-line markers", () => {
+    // This form is not emitted by `createManualSection` and is now rejected
+    // by the indent-aware regex (which requires each marker to be on its own
+    // line). Historical behaviour also extracted this shape, but that came
+    // with a bug where multi-line bodies were only dedented on the first
+    // line.
     expect(
       extractManualSections(
         '/* BEGIN MANUAL SECTION key */console.log("code");/* END MANUAL SECTION */',
       ),
-    ).toEqual({
-      key: 'console.log("code");',
-    });
+    ).toEqual({});
   });
 
-  test("should extract multiline manual section", () => {
+  test("should extract and dedent a multiline manual section", () => {
     expect(
       extractManualSections(`
         class One extends Zero {
@@ -115,11 +118,11 @@ describe(extractManualSections, () => {
       `),
     ).toEqual({
       key: `console.log("line one"); // Comment
-            console.log("line two");`,
+console.log("line two");`,
     });
   });
 
-  test("should extract multiple manual sections", () => {
+  test("should extract multiple manual sections, dedenting each one", () => {
     expect(
       extractManualSections(`
         /* BEGIN MANUAL SECTION custom-imports_empty_section */
@@ -144,9 +147,9 @@ describe(extractManualSections, () => {
     ).toEqual({
       "custom-imports_empty_section": "",
       "One-constructor_with_code": `console.log("custom constructor");
-            /* BEGIN some other thing */
-            console.log("more custom constructing");
-            /* END some other thing */`,
+/* BEGIN some other thing */
+console.log("more custom constructing");
+/* END some other thing */`,
       "custom-methods_blank_line_section": "",
     });
   });
@@ -180,17 +183,12 @@ describe(emptyManualSections, () => {
     );
   });
 
-  function expectedEmptySectionForSectionKey(key: string) {
-    return `/* BEGIN MANUAL SECTION ${key} */
-/* END MANUAL SECTION */`;
+  function expectedEmptySectionForSectionKey(key: string, indent = "") {
+    return `${indent}/* BEGIN MANUAL SECTION ${key} */
+${indent}/* END MANUAL SECTION */`;
   }
 
   test("should reset an empty manual section", () => {
-    expect(
-      emptyManualSections(
-        "/* BEGIN MANUAL SECTION key *//* END MANUAL SECTION */",
-      ),
-    ).toBe(expectedEmptySectionForSectionKey("key"));
     expect(
       emptyManualSections(
         "/* BEGIN MANUAL SECTION key */\n/* END MANUAL SECTION */",
@@ -203,23 +201,23 @@ describe(emptyManualSections, () => {
     ).toBe(expectedEmptySectionForSectionKey("key"));
   });
 
-  test("should empty single line manual section", () => {
-    expect(
-      emptyManualSections(
-        '/* BEGIN MANUAL SECTION key */console.log("code");/* END MANUAL SECTION */',
-      ),
-    ).toBe(expectedEmptySectionForSectionKey("key"));
-  });
-
   test("should empty multiline manual section", () => {
     expect(
       emptyManualSections(
-        '/* BEGIN MANUAL SECTION key */\nconsole.log("one");\nconsole.log("two");/* END MANUAL SECTION */',
+        '/* BEGIN MANUAL SECTION key */\nconsole.log("one");\nconsole.log("two");\n/* END MANUAL SECTION */',
       ),
     ).toBe(expectedEmptySectionForSectionKey("key"));
   });
 
-  test("should empty multiple manual sections", () => {
+  test("should preserve indent when emptying an indented manual section", () => {
+    expect(
+      emptyManualSections(`    /* BEGIN MANUAL SECTION key */
+    console.log("one");
+    /* END MANUAL SECTION */`),
+    ).toBe(expectedEmptySectionForSectionKey("key", "    "));
+  });
+
+  test("should empty multiple manual sections, preserving each one's indent", () => {
     expect(
       emptyManualSections(`
         /* BEGIN MANUAL SECTION custom-imports_empty_section */
@@ -243,17 +241,17 @@ describe(emptyManualSections, () => {
       `),
     ).toBe(`
         /* BEGIN MANUAL SECTION custom-imports_empty_section */
-/* END MANUAL SECTION */
+        /* END MANUAL SECTION */
 
         class One extends Zero {
           constructor() {
             this.value = 1;
             /* BEGIN MANUAL SECTION One-constructor_with_code */
-/* END MANUAL SECTION */
+            /* END MANUAL SECTION */
           }
 
           /* BEGIN MANUAL SECTION custom-methods_blank_line_section */
-/* END MANUAL SECTION */
+          /* END MANUAL SECTION */
         }
       `);
   });

--- a/src/sections/manual.ts
+++ b/src/sections/manual.ts
@@ -126,15 +126,12 @@ export function extractManualSections(
   syntax: CommentSyntax = DEFAULT_COMMENT_SYNTAX,
 ): ManualSectionMap {
   const regExp = getSectionMatchRegExp(syntax);
-  const allMatches = code.matchAll(regExp);
   const manualSections: ManualSectionMap = {};
-  [...allMatches].forEach((match: RegExpMatchArray) => {
-    if (!match.groups) {
-      return;
-    }
-    const { key, code: body, indent = "" } = match.groups;
+  for (const match of code.matchAll(regExp)) {
+    // The regex always has named groups, so `match.groups` is always defined.
+    const { key, code: body, indent = "" } = match.groups!;
     manualSections[key] = dedent(body, indent).trim();
-  });
+  }
   return manualSections;
 }
 
@@ -155,12 +152,12 @@ export function emptyManualSections(
 ): string {
   const regExp = getSectionMatchRegExp(syntax);
   return code.replace(regExp, (...args) => {
-    const groups = args[args.length - 1] as
-      | { key: string; indent?: string }
-      | undefined;
-    if (!groups) {
-      return args[0] as string;
-    }
+    // The regex always has named groups, so the last positional argument is
+    // always the groups object.
+    const groups = args[args.length - 1] as {
+      key: string;
+      indent?: string;
+    };
     return createManualSection(groups.key, "", syntax, groups.indent ?? "");
   });
 }

--- a/src/sections/manual.ts
+++ b/src/sections/manual.ts
@@ -1,8 +1,15 @@
 import type { ManualSectionMap } from "../types/ManualSectionMap";
 import { CommentSyntax, DEFAULT_COMMENT_SYNTAX } from "../types/CommentSyntax";
 
+/**
+ * JSDoc manual-section markers. Each marker must be on its own line (leading
+ * and trailing whitespace only); the BEGIN marker's leading whitespace is
+ * captured as `indent` and the END marker is required to share it via the
+ * named backreference, so the lazy `code` capture cannot straddle a
+ * differently-indented END marker.
+ */
 const jsdocSectionMatchRegExp =
-  /\/\* BEGIN MANUAL SECTION (?<key>\S+) \*\/(?<code>(.|\n)+?|)\/\* END MANUAL SECTION \*\//gm;
+  /^(?<indent>[ \t]*)\/\* BEGIN MANUAL SECTION (?<key>\S+) \*\/[ \t]*$\n(?<code>[\s\S]*?)^\k<indent>\/\* END MANUAL SECTION \*\/[ \t]*$/gm;
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -10,10 +17,8 @@ function escapeRegExp(value: string): string {
 
 function buildLineSectionMatchRegExp(prefix: string): RegExp {
   const escapedPrefix = escapeRegExp(prefix);
-  // Anchor both markers to a line start (via the `m` flag) so that the lazy
-  // `code` capture does not greedily swallow an intervening END marker.
   return new RegExp(
-    `^${escapedPrefix}BEGIN MANUAL SECTION (?<key>\\S+)$\\n(?<code>[\\s\\S]*?)^${escapedPrefix}END MANUAL SECTION$`,
+    `^(?<indent>[ \\t]*)${escapedPrefix}BEGIN MANUAL SECTION (?<key>\\S+)[ \\t]*$\\n(?<code>[\\s\\S]*?)^\\k<indent>${escapedPrefix}END MANUAL SECTION[ \\t]*$`,
     "gm",
   );
 }
@@ -36,10 +41,55 @@ function validateSectionKey(sectionKey: string): void {
   }
 }
 
+/**
+ * Strip `indent` from each line of `code`.
+ *
+ * Lines that do not start with `indent` are left untouched — if a user
+ * hand-edits a manual section and mangles the leading whitespace on a line,
+ * we preserve that edit verbatim rather than silently reshifting it.
+ */
+function dedent(code: string, indent: string): string {
+  if (indent.length === 0) {
+    return code;
+  }
+  return code
+    .split("\n")
+    .map((line) =>
+      line.startsWith(indent) ? line.substring(indent.length) : line,
+    )
+    .join("\n");
+}
+
+/**
+ * Prepend `indent` to each non-empty line of `code`. Empty lines are left
+ * as-is so we never emit trailing whitespace.
+ */
+function applyIndent(code: string, indent: string): string {
+  if (indent.length === 0) {
+    return code;
+  }
+  return code
+    .split("\n")
+    .map((line) => (line.length === 0 ? line : `${indent}${line}`))
+    .join("\n");
+}
+
+/**
+ * Emit a manual section.
+ *
+ * @param sectionKey Non-empty, whitespace-free identifier for this section.
+ * @param sectionCode Section body. Pass as _semantic_ content (i.e. at
+ * column 0); any ambient indent should be supplied via `indent`, not baked
+ * into the body. The body is trimmed of leading/trailing whitespace.
+ * @param syntax Comment syntax. Defaults to JSDoc.
+ * @param indent Whitespace prepended to every emitted line (both markers and
+ * each body line). Defaults to empty string.
+ */
 export function createManualSection(
   sectionKey: string,
   sectionCode: string,
   syntax: CommentSyntax = DEFAULT_COMMENT_SYNTAX,
+  indent = "",
 ): string {
   validateSectionKey(sectionKey);
 
@@ -47,14 +97,30 @@ export function createManualSection(
   processedSectionCode =
     processedSectionCode.length > 0 ? `${processedSectionCode}\n` : "";
 
+  let rawBlock: string;
   if (syntax.kind === "jsdoc") {
-    return `/* BEGIN MANUAL SECTION ${sectionKey} */\n${processedSectionCode}/* END MANUAL SECTION */`;
+    rawBlock = `/* BEGIN MANUAL SECTION ${sectionKey} */\n${processedSectionCode}/* END MANUAL SECTION */`;
+  } else {
+    const { prefix } = syntax;
+    rawBlock = `${prefix}BEGIN MANUAL SECTION ${sectionKey}\n${processedSectionCode}${prefix}END MANUAL SECTION`;
   }
 
-  const { prefix } = syntax;
-  return `${prefix}BEGIN MANUAL SECTION ${sectionKey}\n${processedSectionCode}${prefix}END MANUAL SECTION`;
+  return applyIndent(rawBlock, indent);
 }
 
+/**
+ * Extract manual sections from `code`.
+ *
+ * Each section's body is returned as _semantic content_: any common leading
+ * whitespace shared by the BEGIN marker and the body lines is stripped, so
+ * the returned string is what the author conceptually wrote inside the
+ * section, independent of where the section lives in the file.
+ *
+ * The regenerating code is expected to reapply an appropriate indent when
+ * re-emitting the section — typically by scoping the builder with
+ * `CodeBuilder.indent()` so the original BEGIN column is restored
+ * automatically.
+ */
 export function extractManualSections(
   code: string,
   syntax: CommentSyntax = DEFAULT_COMMENT_SYNTAX,
@@ -66,13 +132,19 @@ export function extractManualSections(
     if (!match.groups) {
       return;
     }
-    manualSections[match.groups.key] = match.groups.code.trim();
+    const { key, code: body, indent = "" } = match.groups;
+    manualSections[key] = dedent(body, indent).trim();
   });
   return manualSections;
 }
 
 /**
- * Removes all code between manual section designators.
+ * Remove all code between manual section designators.
+ *
+ * Each section is replaced by its empty form, preserving the BEGIN marker's
+ * indent so the surrounding file shape is unchanged. This is what the
+ * codelock hash is computed over, so its output is a stable normalized form
+ * given a particular input.
  *
  * @param code Source code, potentially containing manual sections.
  * @param syntax Comment syntax used in the file. Defaults to JSDoc.
@@ -82,7 +154,13 @@ export function emptyManualSections(
   syntax: CommentSyntax = DEFAULT_COMMENT_SYNTAX,
 ): string {
   const regExp = getSectionMatchRegExp(syntax);
-  return code.replace(regExp, (_matchedString, sectionKey) =>
-    createManualSection(sectionKey, "", syntax),
-  );
+  return code.replace(regExp, (...args) => {
+    const groups = args[args.length - 1] as
+      | { key: string; indent?: string }
+      | undefined;
+    if (!groups) {
+      return args[0] as string;
+    }
+    return createManualSection(groups.key, "", syntax, groups.indent ?? "");
+  });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Make manual sections and `CodeBuilder` emissions first-class in indentation-sensitive languages. Adds a new `CodeBuilder.indent(amount, fn)` scope, makes `extractManualSections` indent-aware, and ships end-to-end snapshot examples for Python, YAML, Makefile, Terraform, SQL, and TypeScript.

## The design

Each `CodeBuilder` tracks an ambient indent string. `addLine` / `add` / `addDocblock` / `addManualSection` all apply that indent to every emitted line. You enter a deeper indent via:

```typescript
b.indent("    ", (b) => b.addLine("..."));
```

Indent scopes compose additively: `indent("  ", b => b.indent("  ", bb => …))` produces four spaces. `indent()` accepts any string, so spaces, tabs, and mixed prefixes all work — covering Python, YAML, Terraform/HCL, Makefile recipes, and anything else where column position matters.

The key round-trip invariant: **stored manual-section bodies are always semantic (column-0) content**. `extractManualSections` auto-detects each section's indent from its BEGIN marker and dedents the body uniformly; re-emission reapplies whatever ambient indent the builder is sitting in. So a human who edits this:

```python
    # BEGIN MANUAL SECTION postprocess
    return result
    # END MANUAL SECTION
```

into this:

```python
    # BEGIN MANUAL SECTION postprocess
    if result > 100:
        raise ValueError(result)
    return result
    # END MANUAL SECTION
```

will see their edits preserved **byte-identically** after regeneration, with the nested `raise` keeping its 4-space relative indent.

## Changes at a glance

- **`src/sections/manual.ts`**
  - Marker regex now requires each marker on its own line, captures the BEGIN's leading whitespace as a named `indent` group, and requires the END to share that indent via `\k<indent>`. The lazy body capture therefore cannot straddle a differently-indented END marker.
  - `extractManualSections` dedents the body by the captured indent before trimming. This fixes a latent bug: previously `.trim()` on the whole body only dedented line 1, so multi-line bodies kept the original indent on lines 2+.
  - `createManualSection` accepts a new optional `indent` argument that is applied to both markers and body lines. Empty lines are emitted without the prefix so we never produce trailing whitespace.
  - `emptyManualSections` preserves the BEGIN indent on the empty normalized form.

- **`src/CodeBuilder.ts`**
  - Tracks an ambient indent string + `atLineStart` flag. `add`/`addLine` apply the ambient indent to every new line (blank lines stay blank).
  - New `indent(amount, fn)` method opens a nested builder whose indent is parent + `amount`. Propagates `hasManualSections` back to the parent.
  - `addBlock` / `addManualSection` still build children at column 0 so stored section bodies splice in cleanly; the parent's indent is reapplied at emit time.

- **`src/CodeBuilder.test.ts`** — eight new unit tests for `indent()` covering composition, blank-line handling, manual-section round-trip, `hasManualSections` propagation, tab-indent, and mid-line `add()` cases.

- **`src/sections/manual.test.ts`** — updates three existing tests that asserted the previous (buggy) per-line dedent behaviour; adds tests that pin the correct behaviour for indented multi-line bodies.

- **`src/integration.test.ts`** — adds ten new end-to-end snapshot examples:
  - Python module with a manual section inside a function body, including a nested indent scope within the section body (`if`/`total = round(...)`) that round-trips cleanly
  - Python class with manual sections at two different indentation levels
  - Python regeneration test showing human-edited indented manual section content preserved verbatim
  - YAML docker-compose fragment with a manual section inside a nested mapping whose body contains further indentation (`environment: / - NODE_ENV=...`)
  - Makefile with a tab-indented recipe whose manual section uses the tab-indent convention
  - Terraform `main.tf` with 3-level HCL nesting (`terraform { required_providers { aws { ... } } }`, `resource { lifecycle_rule { expiration { ... } } }`), a manual section buried 4 levels deep inside `tags = { ... }`, and a top-level manual section for extra resources
  - Terraform regeneration test proving that aligned tag assignments added by a human inside the nested manual section round-trip byte-identically
  - SQL `CREATE TABLE` with a manual section inside the indented column list, using `{ kind: "line", prefix: "-- " }` to exercise a distinct prefix family
  - **Deeper re-indent regeneration**: the section moves from 1 level (inside a function) to 2 levels (wrapped in a class), and the whole section — markers, body, and the body's *internal* nested indent — shifts uniformly.
  - **Shallower re-indent regeneration**: the section moves from 2 levels deep back to column 0, with no stale indent left behind.

- **`README.md`**
  - New "Generating indentation-sensitive languages" section with Python and Terraform examples end-to-end, explaining the round-trip semantics for human edits.
  - New "Supported file types by `CommentSyntax`" table mapping common target file types (TypeScript, Go, Rust, Kotlin, Java, Python, Ruby, Shell, YAML, TOML, Dockerfile, Terraform, Makefile, SQL, CSS, Protobuf, GraphQL, `.gitattributes`, nginx, systemd, etc.) to the corresponding config.
  - "Known limitations" section calling out JSON (no comment syntax), XML/HTML wrapped comments, and shebang displacement by `lock()`.

- **`CHANGELOG.md`** — records Added/Changed/Breaking items under `[Unreleased]`.

## Breaking changes

- **Codelock hashes produced prior to this release no longer verify.** The normalized form consumed by `emptyManualSections` (the input to the codelock hash) now preserves the BEGIN marker's indent, and `createManualSection`'s output for multi-line inputs is now correctly dedented rather than partially dedented. Files locked by earlier versions must be regenerated.
- Manual-section markers must each appear on their own line. The historical regex also matched the pathological single-line form `/* BEGIN MANUAL SECTION k */body/* END MANUAL SECTION */`, which is never emitted by `createManualSection` and is now ignored.

## Backwards compatibility

- `CodeBuilder` gains a new optional third constructor parameter (`indent`, defaulting to `""`). No existing call sites need to change.
- All public method signatures on `CodeFile`, `CodeBuilder`, `createManualSection`, `extractManualSections`, and `emptyManualSections` remain source-compatible (new parameters are optional).
- The Steam/Greeter/TypeScript snapshots continue to produce semantically identical output when run through Prettier.

## Verification

- `yarn test` → 112/112 passing across six test suites; 23 snapshots (18 integration examples + 5 other snapshots)
- `yarn typecheck` → clean
- `yarn lint` → clean
- `yarn build` → clean
- Manual coverage smoke test confirms the cross-indent-level regeneration flows produce byte-identical output for both deeper and shallower moves.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cd3642d-6c21-4fc5-a170-cbce5c568299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cd3642d-6c21-4fc5-a170-cbce5c568299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

