### PR TITLE
Cache Prettier config resolution to make .format() faster

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,5 +3,6 @@ eslint.config.mjs
 vitest.config.ts
 tsconfig.*
 src
+bench
 test-reports
 coverage

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,89 @@
+# tscodegen perf benchmarks
+
+Run `node bench/bench.mjs` after `yarn build` to reproduce.
+
+## What dominates runtime
+
+In a typical end-to-end task (build a file, format with Prettier, lock,
+save), **Prettier accounts for ~85–95% of wall time.** The codegen layer
+itself (`CodeBuilder`, manual-section extraction, codelock hash) handles
+even a 1000-line file in ~0.25 ms — there is essentially no headroom for
+a Rust/WASM rewrite of that layer to claw back.
+
+The remaining cost lives in two places inside `format()`:
+
+1. **Prettier config resolution.** `resolveConfigFile()` + `resolveConfig()`
+   walk the filesystem from cwd looking for `.prettierrc`. Measured at
+   ~6.6 ms per call. Before the cache fix, this ran on every single
+   `.format()` invocation.
+2. **Prettier formatting itself.** Parsing TypeScript and re-emitting it
+   is the actual heavy work: ~1.4 ms for a tiny file, ~48 ms for 1000
+   lines. There is no way to speed Prettier itself up from inside this
+   library.
+
+## Current results (after the cwd-keyed config cache)
+
+| operation                                  | before  | after   | speedup |
+| ------------------------------------------ | ------- | ------- | ------- |
+| tiny (5 lines), format, lock               | 8.47 ms | 1.49 ms | 5.7x    |
+| medium (100 lines), format, lock           | 11.28 ms| 4.31 ms | 2.6x    |
+| large (1000 lines), format, lock           | 55.66 ms| 48.03 ms| 1.16x   |
+| tiny, no format, lock                      | 52 µs   | 47 µs   | —       |
+| medium (100 lines), no format, lock        | 68 µs   | 64 µs   | —       |
+| large (1000 lines), no format, lock        | 261 µs  | 232 µs  | —       |
+| regen w/ 50 manual sections, lock          | 184 µs  | 143 µs  | —       |
+
+The `no format` rows are unchanged; the codegen layer was already fast.
+The diminishing speedup as files grow is expected: Prettier itself
+dominates large-file runtime, and the cache fix only removes the
+constant per-call overhead.
+
+## What about a Rust/WASM port?
+
+Profiled separately. The non-format pipeline emits a 1000-line file in
+~232 µs. Even an idealised 100x port of that layer would shave ~230 µs
+off a 48 ms end-to-end large-file operation — under 0.5%. Not worth the
+distribution cost (per-platform prebuilt binaries or a 1–5 MB WASM
+bundle) and the loss of native-JS ergonomics.
+
+The only meaningful Rust angle is **swapping Prettier for a Rust-based
+formatter.** A throwaway prototype using Biome (Rust, distributed as a
+WASM module via npm) measured:
+
+| operation                       | Prettier (cached) | Biome WASM | factor |
+| ------------------------------- | ----------------- | ---------- | ------ |
+| tiny, format, lock              | 1.49 ms           | 0.34 ms    | 4.4x   |
+| medium (100 lines), format, lock| 4.31 ms           | 1.78 ms    | 2.4x   |
+| large (1000 lines), format, lock| 48.03 ms          | 10.31 ms   | 4.7x   |
+| pure format(1000 lines)         | 49.30 ms          | 9.57 ms    | 5.1x   |
+
+Caveats: Biome's output is not byte-identical to Prettier's (different
+defaults: tabs vs spaces, different wrapping heuristics), so it cannot
+be a transparent drop-in. The right shape would be an optional formatter
+hook (`format({ engine: "biome" })` or a pluggable formatter argument),
+not a wholesale swap.
+
+## Stacking the wins
+
+| layer                                          | tiny     | large     |
+| ---------------------------------------------- | -------- | --------- |
+| baseline                                       | 8.47 ms  | 55.66 ms  |
+| + cached prettier config (shipped)             | 1.49 ms  | 48.03 ms  |
+| + biome instead of prettier (opt-in, hypothetical) | 0.34 ms | 10.31 ms |
+| + no formatter at all (already possible)       | 0.05 ms  | 0.23 ms   |
+
+100x is only achievable by not formatting (which already works — just
+don't call `.format()`). Realistic optimised path: ~5–25x via the config
+cache + an opt-in Biome formatter.
+
+## Reproducing the Biome numbers
+
+```sh
+yarn add -D @biomejs/js-api @biomejs/wasm-nodejs
+node bench/bench-biome.mjs
+```
+
+`bench-biome.mjs` runs the same end-to-end pipeline but pipes the
+generated code through Biome's WASM `formatContent` instead of calling
+`.format()`. It's kept around as a documented experiment; Biome is not a
+runtime dependency.

--- a/bench/bench-biome.mjs
+++ b/bench/bench-biome.mjs
@@ -1,0 +1,80 @@
+// Compares end-to-end perf when Biome (WASM, Rust) is used in place of Prettier.
+// We replicate the CodeBuilder/CodeFile pipeline but swap the formatter.
+import { performance } from "node:perf_hooks";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+import { Biome } from "@biomejs/js-api/nodejs";
+import { CodeBuilder } from "../dist/CodeBuilder.js";
+import { CodeFile } from "../dist/index.js";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "tscodegen-biome-"));
+
+const biome = new Biome();
+const { projectKey } = biome.openProject();
+
+function repeat(n, fn) {
+  for (let i = 0; i < Math.min(3, n); i++) fn(i);
+  const t0 = performance.now();
+  for (let i = 0; i < n; i++) fn(i);
+  return (performance.now() - t0) / n;
+}
+function fmt(ms) {
+  if (ms < 1) return `${(ms * 1000).toFixed(1)} µs`;
+  if (ms < 1000) return `${ms.toFixed(2)} ms`;
+  return `${(ms / 1000).toFixed(2)} s`;
+}
+function bench(name, n, fn) {
+  const ms = repeat(n, fn);
+  console.log(`${name.padEnd(60)}  n=${String(n).padStart(5)}  ${fmt(ms)}/op`);
+}
+
+// Same shape as bench.mjs but with Biome-format-instead-of-prettier
+function biomeFormat(code) {
+  return biome.formatContent(projectKey, code, { filePath: "f.ts" }).content;
+}
+
+// 3-equiv: tiny format
+bench("[biome] tiny: 5 lines, format, lock", 200, (i) => {
+  const p = path.join(TMP, `t-${i}.ts`);
+  const cf = new CodeFile(p);
+  cf.build((b) => {
+    for (let j = 0; j < 5; j++) b.add(`const a${j}=${j};\n`);
+    // post-process via biome instead of .format()
+    const code = b.toString();
+    return new CodeBuilder({}).add(biomeFormat(code));
+  })
+    .lock()
+    .saveToFile();
+});
+
+bench("[biome] medium: 100 lines, format, lock", 100, (i) => {
+  const p = path.join(TMP, `m-${i}.ts`);
+  const cf = new CodeFile(p);
+  cf.build((b) => {
+    for (let j = 0; j < 100; j++) b.add(`const x${j}=${j};\n`);
+    const code = b.toString();
+    return new CodeBuilder({}).add(biomeFormat(code));
+  })
+    .lock()
+    .saveToFile();
+});
+
+bench("[biome] large: 1000 lines, format, lock", 30, (i) => {
+  const p = path.join(TMP, `l-${i}.ts`);
+  const cf = new CodeFile(p);
+  cf.build((b) => {
+    for (let j = 0; j < 1000; j++) b.add(`const x${j}=${j};\n`);
+    const code = b.toString();
+    return new CodeBuilder({}).add(biomeFormat(code));
+  })
+    .lock()
+    .saveToFile();
+});
+
+// Pure-format micro
+{
+  let code = "";
+  for (let j = 0; j < 1000; j++) code += `const x${j}=${j};\n`;
+  bench("[biome] micro: format(1000 lines)", 30, () => biomeFormat(code));
+}

--- a/bench/bench.mjs
+++ b/bench/bench.mjs
@@ -1,0 +1,176 @@
+// End-to-end perf benchmarks for tscodegen.
+// Run with: node bench/bench.mjs
+import { performance } from "node:perf_hooks";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+import { CodeFile } from "../dist/index.js";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "tscodegen-bench-"));
+const repeat = (n, fn) => {
+  // warmup
+  for (let i = 0; i < Math.min(3, n); i++) fn(i);
+  const t0 = performance.now();
+  for (let i = 0; i < n; i++) fn(i);
+  const t1 = performance.now();
+  return (t1 - t0) / n;
+};
+
+function fmt(ms) {
+  if (ms < 1) return `${(ms * 1000).toFixed(1)} µs`;
+  if (ms < 1000) return `${ms.toFixed(2)} ms`;
+  return `${(ms / 1000).toFixed(2)} s`;
+}
+
+const cases = [];
+
+function bench(name, n, fn) {
+  const ms = repeat(n, fn);
+  cases.push({ name, n, ms });
+  console.log(`${name.padEnd(60)}  n=${String(n).padStart(5)}  ${fmt(ms)}/op`);
+}
+
+// 1. tiny file, no format, no lock
+bench("tiny: addLine x5, no format, no lock", 1000, (i) => {
+  const p = path.join(TMP, `tiny-${i}.ts`);
+  new CodeFile(p)
+    .build((b) => b.addLine("const a = 1;").addLine("const b = 2;").addLine("const c = 3;").addLine("const d = 4;").addLine("const e = 5;"))
+    .saveToFile();
+});
+
+// 2. tiny file, no format, lock
+bench("tiny: addLine x5, no format, lock", 1000, (i) => {
+  const p = path.join(TMP, `tiny-lock-${i}.ts`);
+  new CodeFile(p)
+    .build((b) => b.addLine("const a = 1;").addLine("const b = 2;").addLine("const c = 3;").addLine("const d = 4;").addLine("const e = 5;"))
+    .lock()
+    .saveToFile();
+});
+
+// 3. tiny file with prettier .format()
+bench("tiny: addLine x5, format, lock", 200, (i) => {
+  const p = path.join(TMP, `tiny-fmt-${i}.ts`);
+  new CodeFile(p)
+    .build((b) =>
+      b
+        .addLine("const a=1;").addLine("const b=2;").addLine("const c=3;").addLine("const d=4;").addLine("const e=5;")
+        .format(),
+    )
+    .lock()
+    .saveToFile();
+});
+
+// 4. medium file (100 lines) no format
+bench("medium: 100 lines, no format, lock", 500, (i) => {
+  const p = path.join(TMP, `med-${i}.ts`);
+  new CodeFile(p)
+    .build((b) => {
+      for (let j = 0; j < 100; j++) b.addLine(`const x${j} = ${j};`);
+      return b;
+    })
+    .lock()
+    .saveToFile();
+});
+
+// 5. medium file (100 lines) WITH format
+bench("medium: 100 lines, format, lock", 100, (i) => {
+  const p = path.join(TMP, `med-fmt-${i}.ts`);
+  new CodeFile(p)
+    .build((b) => {
+      for (let j = 0; j < 100; j++) b.addLine(`const x${j}=${j};`);
+      return b.format();
+    })
+    .lock()
+    .saveToFile();
+});
+
+// 6. large file (1000 lines), no format
+bench("large: 1000 lines, no format, lock", 100, (i) => {
+  const p = path.join(TMP, `lg-${i}.ts`);
+  new CodeFile(p)
+    .build((b) => {
+      for (let j = 0; j < 1000; j++) b.addLine(`const x${j} = ${j};`);
+      return b;
+    })
+    .lock()
+    .saveToFile();
+});
+
+// 7. large file (1000 lines) WITH format
+bench("large: 1000 lines, format, lock", 30, (i) => {
+  const p = path.join(TMP, `lg-fmt-${i}.ts`);
+  new CodeFile(p)
+    .build((b) => {
+      for (let j = 0; j < 1000; j++) b.addLine(`const x${j}=${j};`);
+      return b.format();
+    })
+    .lock()
+    .saveToFile();
+});
+
+// 8. manual section extraction on a file with many sections
+{
+  // Build a file with 50 manual sections then re-read it
+  const seedPath = path.join(TMP, `seed-manual.ts`);
+  new CodeFile(seedPath)
+    .build((b) => {
+      for (let j = 0; j < 50; j++) {
+        b.addLine(`const x${j} = ${j};`).addManualSection(`s${j}`, (mb) =>
+          mb.addLine(`/* user edit ${j} */`),
+        );
+      }
+      return b;
+    })
+    .lock()
+    .saveToFile();
+  bench("regen: read file w/ 50 manual sections, regen, lock", 200, (i) => {
+    new CodeFile(seedPath)
+      .build((b) => {
+        for (let j = 0; j < 50; j++) {
+          b.addLine(`const x${j} = ${j};`).addManualSection(`s${j}`, (mb) =>
+            mb.addLine(`/* default ${j} */`),
+          );
+        }
+        return b;
+      })
+      .lock()
+      .saveToFile();
+  });
+}
+
+// 9. micro: just CodeBuilder (no fs, no format, no lock)
+import { CodeBuilder } from "../dist/CodeBuilder.js";
+bench("micro: CodeBuilder 1000 addLine", 1000, () => {
+  const b = new CodeBuilder({});
+  for (let j = 0; j < 1000; j++) b.addLine(`const x${j} = ${j};`);
+  b.toString();
+});
+
+// 10. micro: hash (codelock) on 1000-line content
+import { lockCode, verifyLock } from "../dist/codelock.js";
+{
+  let code = "";
+  for (let j = 0; j < 1000; j++) code += `const x${j} = ${j};\n`;
+  bench("micro: lockCode (1000 lines)", 1000, () => {
+    lockCode(code, false);
+  });
+  const locked = lockCode(code, false);
+  bench("micro: verifyLock (1000 lines)", 1000, () => {
+    verifyLock(locked);
+  });
+}
+
+// 11. micro: prettier alone (1000 lines)
+import syncPrettier from "@prettier/sync";
+{
+  let code = "";
+  for (let j = 0; j < 1000; j++) code += `const x${j}=${j};\n`;
+  bench("micro: prettier format (1000 lines)", 30, () => {
+    syncPrettier.format(code, { parser: "typescript" });
+  });
+}
+
+// Write a JSON summary
+const out = path.join(process.cwd(), "bench/results.json");
+fs.writeFileSync(out, JSON.stringify(cases, null, 2));
+console.log(`\nWrote ${out}`);

--- a/bench/results-baseline.txt
+++ b/bench/results-baseline.txt
@@ -1,0 +1,14 @@
+tiny: addLine x5, no format, no lock                          n= 1000  49.6 µs/op
+tiny: addLine x5, no format, lock                             n= 1000  52.3 µs/op
+tiny: addLine x5, format, lock                                n=  200  8.47 ms/op
+medium: 100 lines, no format, lock                            n=  500  67.9 µs/op
+medium: 100 lines, format, lock                               n=  100  11.28 ms/op
+large: 1000 lines, no format, lock                            n=  100  261.3 µs/op
+large: 1000 lines, format, lock                               n=   30  55.66 ms/op
+regen: read file w/ 50 manual sections, regen, lock           n=  200  184.3 µs/op
+micro: CodeBuilder 1000 addLine                               n= 1000  124.5 µs/op
+micro: lockCode (1000 lines)                                  n= 1000  48.9 µs/op
+micro: verifyLock (1000 lines)                                n= 1000  44.6 µs/op
+micro: prettier format (1000 lines)                           n=   30  48.25 ms/op
+
+Wrote /home/user/tscodegen/bench/results.json

--- a/bench/results-biome.txt
+++ b/bench/results-biome.txt
@@ -1,0 +1,4 @@
+[biome] tiny: 5 lines, format, lock                           n=  200  341.0 µs/op
+[biome] medium: 100 lines, format, lock                       n=  100  1.78 ms/op
+[biome] large: 1000 lines, format, lock                       n=   30  10.31 ms/op
+[biome] micro: format(1000 lines)                             n=   30  9.57 ms/op

--- a/bench/results-cached-config-final.txt
+++ b/bench/results-cached-config-final.txt
@@ -1,0 +1,14 @@
+tiny: addLine x5, no format, no lock                          n= 1000  33.4 µs/op
+tiny: addLine x5, no format, lock                             n= 1000  47.3 µs/op
+tiny: addLine x5, format, lock                                n=  200  1.49 ms/op
+medium: 100 lines, no format, lock                            n=  500  63.9 µs/op
+medium: 100 lines, format, lock                               n=  100  4.31 ms/op
+large: 1000 lines, no format, lock                            n=  100  231.5 µs/op
+large: 1000 lines, format, lock                               n=   30  48.03 ms/op
+regen: read file w/ 50 manual sections, regen, lock           n=  200  143.2 µs/op
+micro: CodeBuilder 1000 addLine                               n= 1000  94.9 µs/op
+micro: lockCode (1000 lines)                                  n= 1000  46.0 µs/op
+micro: verifyLock (1000 lines)                                n= 1000  44.0 µs/op
+micro: prettier format (1000 lines)                           n=   30  49.30 ms/op
+
+Wrote /home/user/tscodegen/bench/results.json

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,13 @@ import globals from "globals";
 
 export default [
   {
-    ignores: ["dist/**", "coverage/**", "test-reports/**", "node_modules/**"],
+    ignores: [
+      "dist/**",
+      "coverage/**",
+      "test-reports/**",
+      "node_modules/**",
+      "bench/**",
+    ],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,

--- a/src/CodeBuilder.test.ts
+++ b/src/CodeBuilder.test.ts
@@ -263,6 +263,49 @@ in the block.
       }
     });
 
+    test("should not leak resolved prettier config across different cwds", () => {
+      // Regression test for the cwd-keyed config cache: two adjacent
+      // format() calls in different cwds with different prettier
+      // configs must each use their own config, not whatever was
+      // cached first.
+      const originalCwd = process.cwd();
+      const dirA = fs.mkdtempSync(path.join(os.tmpdir(), "tscodegen-test-A-"));
+      const dirB = fs.mkdtempSync(path.join(os.tmpdir(), "tscodegen-test-B-"));
+      fs.writeFileSync(
+        path.join(dirA, "package.json"),
+        JSON.stringify({
+          name: "a",
+          prettier: { singleQuote: true, semi: false },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(dirB, "package.json"),
+        JSON.stringify({
+          name: "b",
+          prettier: { singleQuote: false, semi: true },
+        }),
+      );
+
+      try {
+        process.chdir(dirA);
+        const a = new CodeBuilder({})
+          .addLine('const hello = "world"')
+          .format()
+          .toString();
+        process.chdir(dirB);
+        const b = new CodeBuilder({})
+          .addLine("const hello = 'world'")
+          .format()
+          .toString();
+        expect(a).toBe("const hello = 'world'\n");
+        expect(b).toBe('const hello = "world";\n');
+      } finally {
+        process.chdir(originalCwd);
+        removeDir(dirA);
+        removeDir(dirB);
+      }
+    });
+
     test("should re-synchronize the at-line-start flag after formatting", () => {
       // Regression test: before the fix, calling format() on a builder
       // with ambient indent left a stale atLineStart from the pre-format

--- a/src/CodeBuilder.ts
+++ b/src/CodeBuilder.ts
@@ -4,6 +4,34 @@ import type { ManualSectionMap } from "./types/ManualSectionMap";
 import { createDocblock } from "./sections/docblock";
 import { CommentSyntax, DEFAULT_COMMENT_SYNTAX } from "./types/CommentSyntax";
 
+type PrettierOptions = Parameters<typeof syncPrettier.format>[1];
+
+// Prettier config resolution walks the filesystem from cwd looking for
+// .prettierrc — measured at ~6.6 ms per call. Codegens that emit many
+// files were paying that cost once per `.format()` invocation. Cache the
+// resolved options keyed by cwd so the work is amortized across calls
+// without ignoring a directory change.
+const prettierOptionsByCwd = new Map<string, PrettierOptions>();
+function getPrettierOptions(): PrettierOptions {
+  const cwd = process.cwd();
+  const cached = prettierOptionsByCwd.get(cwd);
+  if (cached !== undefined) {
+    return cached;
+  }
+  let resolved: PrettierOptions = {};
+  try {
+    const configFilePath = syncPrettier.resolveConfigFile();
+    if (configFilePath) {
+      resolved =
+        syncPrettier.resolveConfig(cwd, { config: configFilePath }) ?? {};
+    }
+  } catch {
+    // Fall back to Prettier defaults when config resolution fails.
+  }
+  prettierOptionsByCwd.set(cwd, resolved);
+  return resolved;
+}
+
 export class CodeBuilder {
   #gennedCode = "";
   #hasManualSections = false;
@@ -187,20 +215,8 @@ export class CodeBuilder {
    * Formats the stored code with Prettier.
    */
   format(): this {
-    let options: Parameters<typeof syncPrettier.format>[1] = {};
-    try {
-      const configFilePath = syncPrettier.resolveConfigFile();
-      if (configFilePath) {
-        options =
-          syncPrettier.resolveConfig(process.cwd(), {
-            config: configFilePath,
-          }) ?? {};
-      }
-    } catch {
-      // Fall back to Prettier defaults when config resolution fails.
-    }
     this.#gennedCode = syncPrettier.format(this.#gennedCode, {
-      ...options,
+      ...getPrettierOptions(),
       parser: "typescript",
     });
     // Resynchronize the line-start flag with the newly-installed code so


### PR DESCRIPTION
Opening this so we can discuss shipping it — the fix, benchmarks, and tests already exist on your own `claude/benchmark-tscodegen-performance-6jWnY` branch in this repo, they just never became a PR. This PR is that branch's content, pushed to my fork so I can open it (I'm not a collaborator here, so couldn't open branch-to-branch directly).

## Context

We (Paraform) consume `@elg/tscodegen@0.5.0` for our store-layer codegen (~214 generated models, ~4 files each). Profiling our own slow codegen run independently led us to the same root cause this branch already fixes: `CodeBuilder.format()` re-resolves the Prettier config from disk (`resolveConfigFile` + `resolveConfig`) on every single call, even though it can't change mid-process.

We'd landed our own stopgap for this — a `pnpm patch` on the installed `0.5.0` package, using a single-value cache — before finding this branch already had a materially better version: keyed by `cwd`, so it doesn't misbehave if `process.cwd()` changes mid-process, plus dedicated regression tests for exactly that (`should not leak resolved prettier config across different cwds`) and for the config-resolution-failure fallback path, which our simpler version didn't cover.

## Independent corroboration

Applying just this fix in our own consumer, measured end-to-end across our actual 214-model codegen run: the per-model generation phase dropped from ~2.79s to ~2.15s (~23% reduction), consistent with the diminishing-returns trend in this PR's own large-file benchmark (1.16x — Prettier's own formatting dominates at scale, but the config-resolution overhead this fixes is still a real, measurable tax on every call).

## What we'd love to see

- This merged and released as a patch/minor version bump.
- Once it ships, we can drop our local patch entirely.

Also noting for the record: the commit message mentions an experimental Biome-based formatter prototype offering another ~3-5x on top — not asking to scope that into this PR, just flagging it's a promising follow-up if there's appetite.

Happy to help however's useful — rebase, add anything, or just bump/tag if it's ready as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)